### PR TITLE
[youth27]Jsonparser step4

### DIFF
--- a/JSONParser/JSONParser/CountInfo.swift
+++ b/JSONParser/JSONParser/CountInfo.swift
@@ -15,23 +15,19 @@ struct CountInfo {
     private (set) var countOfObject : Int
     private (set) var countOfArray : Int
     private (set) var countOfJSONData : Int
-    private (set) var parseType : Parser.ParseTarget
-    
 
     init (countOfInt: Int = 0,
           countOfBool: Int = 0,
           countOfString: Int = 0,
           countOfObject: Int = 0,
           countOfArray: Int = 0,
-          countOfJSONData: Int = 0,
-          parseType: Parser.ParseTarget) {
+          countOfJSONData: Int = 0) {
         self.countOfInt = countOfInt
         self.countOfBool = countOfBool
         self.countOfString = countOfString
         self.countOfObject = countOfObject
         self.countOfArray = countOfArray
         self.countOfJSONData = countOfJSONData
-        self.parseType = parseType
     }
 
 }

--- a/JSONParser/JSONParser/CountInfo.swift
+++ b/JSONParser/JSONParser/CountInfo.swift
@@ -15,19 +15,23 @@ struct CountInfo {
     private (set) var countOfObject : Int
     private (set) var countOfArray : Int
     private (set) var countOfJSONData : Int
+    private (set) var parseType : Parser.ParseTarget
+    
 
     init (countOfInt: Int = 0,
           countOfBool: Int = 0,
           countOfString: Int = 0,
           countOfObject: Int = 0,
           countOfArray: Int = 0,
-          countOfJSONData: Int = 0) {
+          countOfJSONData: Int = 0,
+          parseType: Parser.ParseTarget) {
         self.countOfInt = countOfInt
         self.countOfBool = countOfBool
         self.countOfString = countOfString
         self.countOfObject = countOfObject
         self.countOfArray = countOfArray
         self.countOfJSONData = countOfJSONData
+        self.parseType = parseType
     }
 
 }

--- a/JSONParser/JSONParser/DataTypeConverter.swift
+++ b/JSONParser/JSONParser/DataTypeConverter.swift
@@ -38,12 +38,7 @@ struct DataTypeConverter {
 
     func matchValueType (_ value: String) throws -> JSONData {
         let grammarChecker = GrammarChecker()
-        if let boolValue = Bool(value) {
-            return JSONData.BoolValue(boolValue)
-        }
-        if let intValue = Int(value) {
-            return JSONData.IntegerValue(intValue)
-        }
+       
         if value.contains("{") {
             do {
                 let target = try grammarChecker.execute(value)
@@ -62,6 +57,13 @@ struct DataTypeConverter {
                 throw error
             }
         }
+        if let boolValue = Bool(value) {
+            return JSONData.BoolValue(boolValue)
+        }
+        if let intValue = Int(value) {
+            return JSONData.IntegerValue(intValue)
+        }
+        
         return JSONData.StringValue(value)
     }
 

--- a/JSONParser/JSONParser/DataTypeConverter.swift
+++ b/JSONParser/JSONParser/DataTypeConverter.swift
@@ -50,7 +50,7 @@ struct DataTypeConverter {
         }
         if value.contains("[") {
             do {
-                let target = try grammarChecker.execute(value)
+                let target = try grammarChecker.forNestedArray(value)
                 let parsedData = try Parser.matchValues(target)
                 return parsedData
             } catch let error {

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -42,7 +42,6 @@ struct GrammarChecker {
         return trimString
     }
     
-    
     func execute (_ userInput: String?) throws -> ([String],Parser.ParseTarget) {
         let input = userInput ?? ""
         
@@ -62,36 +61,8 @@ struct GrammarChecker {
         }
         throw GrammarChecker.FormatError.invalidInput
     }
-    
-    func forNestedArray (_ input: String) throws -> ([String],Parser.ParseTarget) {
-        if isValidNestedArray(input) {
-            return (extractNestedArrayValue(input),Parser.ParseTarget.list)
-        } else {
-            throw GrammarChecker.FormatError.invalidArray
-        }
-    }
-    
-    func isValidNestedArray (_ input: String) -> Bool {
-        let formatMatchValues = extractNestedArrayValue(input)
-        for value in formatMatchValues {
-            return isValidValueInArray(value)
-        }
-        return false
-    }
-    
-    func extractNestedArrayValue (_ input: String) -> [String] {
-        do {
-            let regex = try NSRegularExpression(pattern: nestedArrayPattern)
-            let nsInput = input as NSString
-            let matches = regex.matches(in: input, range: NSRange(location: 0, length: nsInput.length))
-            let matchValues = matches.map{nsInput.substring(with: $0.range)}
-            return matchValues
-        } catch {
-            return []
-        }
-    }
-    
-    
+
+    // MARK: Array Check
     
     // #1. Array - format check
     private func extractArrayValue (_ input: String) -> [String] {
@@ -129,6 +100,8 @@ struct GrammarChecker {
         return false
     }
 
+    // MARK: Object Check
+    
     // #1. Object - format Check
     private func extractObjectValue (_ input: String) -> [String] {
         do {
@@ -163,6 +136,36 @@ struct GrammarChecker {
             return isValidValueinObject(value)
         }
         return false
+    }
+    
+    // MARK: Nested Array Check
+    
+    func forNestedArray (_ input: String) throws -> ([String],Parser.ParseTarget) {
+        if isValidNestedArray(input) {
+            return (extractNestedArrayValue(input),Parser.ParseTarget.list)
+        } else {
+            throw GrammarChecker.FormatError.invalidArray
+        }
+    }
+    
+    private func isValidNestedArray (_ input: String) -> Bool {
+        let formatMatchValues = extractNestedArrayValue(input)
+        for value in formatMatchValues {
+            return isValidValueInArray(value)
+        }
+        return false
+    }
+    
+    private func extractNestedArrayValue (_ input: String) -> [String] {
+        do {
+            let regex = try NSRegularExpression(pattern: nestedArrayPattern)
+            let nsInput = input as NSString
+            let matches = regex.matches(in: input, range: NSRange(location: 0, length: nsInput.length))
+            let matchValues = matches.map{nsInput.substring(with: $0.range)}
+            return matchValues
+        } catch {
+            return []
+        }
     }
 
 }

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -47,7 +47,7 @@ struct GrammarChecker {
         
         if input.hasPrefix("[") && input.hasSuffix("]") {
             if isValidArray(input) {
-               return (extractArrayValue(removeBrackets(input)),Parser.ParseTarget.list)
+                return (extractArrayValue(input: removeBrackets(input), regexPattern: arrayPattern),Parser.ParseTarget.list)
             } else {
                 throw GrammarChecker.FormatError.invalidArray
             }
@@ -65,9 +65,9 @@ struct GrammarChecker {
     // MARK: Array Check
     
     // #1. Array - format check
-    private func extractArrayValue (_ input: String) -> [String] {
+    private func extractArrayValue (input: String, regexPattern: String) -> [String] {
         do {
-            let regex = try NSRegularExpression(pattern: arrayPattern)
+            let regex = try NSRegularExpression(pattern: regexPattern)
             let nsInput = input as NSString
             let matches = regex.matches(in: input, range: NSRange(location: 0, length: nsInput.length))
             let matchValues = matches.map{nsInput.substring(with: $0.range)}
@@ -93,7 +93,7 @@ struct GrammarChecker {
     
     // Array - #1, #2 execute
     func isValidArray (_ input: String) -> Bool {
-        let formatMatchValues = extractArrayValue(input)
+        let formatMatchValues = extractArrayValue(input: removeBrackets(input), regexPattern: arrayPattern)
         for value in formatMatchValues {
             return isValidValueInArray(value)
         }
@@ -142,30 +142,18 @@ struct GrammarChecker {
     
     func forNestedArray (_ input: String) throws -> ([String],Parser.ParseTarget) {
         if isValidNestedArray(input) {
-            return (extractNestedArrayValue(input),Parser.ParseTarget.list)
+            return (extractArrayValue(input: input, regexPattern: nestedArrayPattern),Parser.ParseTarget.list)
         } else {
             throw GrammarChecker.FormatError.invalidArray
         }
     }
     
     private func isValidNestedArray (_ input: String) -> Bool {
-        let formatMatchValues = extractNestedArrayValue(input)
+        let formatMatchValues = extractArrayValue(input: input, regexPattern: nestedArrayPattern)
         for value in formatMatchValues {
             return isValidValueInArray(value)
         }
         return false
-    }
-    
-    private func extractNestedArrayValue (_ input: String) -> [String] {
-        do {
-            let regex = try NSRegularExpression(pattern: nestedArrayPattern)
-            let nsInput = input as NSString
-            let matches = regex.matches(in: input, range: NSRange(location: 0, length: nsInput.length))
-            let matchValues = matches.map{nsInput.substring(with: $0.range)}
-            return matchValues
-        } catch {
-            return []
-        }
     }
 
 }

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -11,9 +11,9 @@ import Foundation
 
 struct GrammarChecker {
     
-    let arrayPattern = "true|false|\".+?\"|\\d+|\\{.+?\\}|:"
+    let arrayPattern = "true|false|\".+?\"|(\\d+)|(\\[[^\\[\\]]*\\])|(\\{[^\\{\\}]*\\})"
     let objectPattern = "(\".+?\")\\:(true|false|\\\".+?\\\"|\\d+|\\[.+?\\])"
-    let arrayValuePattern = "(true|false)|(\\{.*\\})|(\\d+)|(\".*\")|(\\[.*\\])"
+    let arrayValuePattern = "true|false|(\\d+)|\".+?\"|(\\[[^\\[\\]]*\\])|(\\{[^\\{\\}]*\\})"
     let objectValuePattern = "(\".*\"):((true|false)|(\\{.*\\})|(\\d+)|(\".*\")|(\\[.*\\]))"
 
     enum FormatError: Error {
@@ -39,7 +39,7 @@ struct GrammarChecker {
         
         if input.hasPrefix("[") && input.hasSuffix("]") {
             if isValidArray(input) {
-               return (extractArrayValue(input),Parser.ParseTarget.list)
+               return (extractArrayValue(input.trimmingCharacters(in: ["[","]"])),Parser.ParseTarget.list)
             } else {
                 throw GrammarChecker.FormatError.invalidArray
             }

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -17,7 +17,7 @@ struct GrammarChecker {
     let objectValuePattern = "(\".*\"):((true|false)|(\\{.*\\})|(\\d+)|(\".*\")|(\\[.*\\]))"
     let nestedArrayPattern = "true|false|\".+?\"|(\\d+)"
 
-    enum FormatError: Error {
+    enum FormatError: Error, CustomStringConvertible {
         case invalidArray
         case invalidObject
         case invalidInput

--- a/JSONParser/JSONParser/OutputVIew.swift
+++ b/JSONParser/JSONParser/OutputVIew.swift
@@ -41,7 +41,7 @@ struct OutputView {
         }
     }
 
-    func showResult(_ countInfo: CountInfo, _ parseType: Parser.ParseTarget) {
+    func showResultMessage(_ countInfo: CountInfo, _ parseType: Parser.ParseTarget) {
         print("\(countInfo.countOfJSONData)개 \(selectType(parseType)) 데이터 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
     }
     

--- a/JSONParser/JSONParser/OutputVIew.swift
+++ b/JSONParser/JSONParser/OutputVIew.swift
@@ -31,19 +31,19 @@ struct OutputView {
         return result
     }
     
-    private func selectType(_ info: CountInfo) -> String {
-        if info.parseType == Parser.ParseTarget.list {
+    private func selectType(_ info: Parser.ParseTarget) -> String {
+        if info == Parser.ParseTarget.list {
             return "배열 데이터"
         }
-        if info.parseType == Parser.ParseTarget.object {
+        if info == Parser.ParseTarget.object {
             return "객체 데이터"
         }
         return "데이터"
     }
     
 
-    func showResult(_ countInfo: CountInfo) {
-        print("\(countInfo.countOfJSONData)개 \(selectType(countInfo)) 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
+    func showResult(_ countInfo: CountInfo, _ parseType: Parser.ParseTarget) {
+        print("\(countInfo.countOfJSONData)개 \(selectType(parseType)) 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
     }
     
 }

--- a/JSONParser/JSONParser/OutputVIew.swift
+++ b/JSONParser/JSONParser/OutputVIew.swift
@@ -32,18 +32,17 @@ struct OutputView {
     }
     
     private func selectType(_ info: Parser.ParseTarget) -> String {
-        if info == Parser.ParseTarget.list {
-            return "배열 데이터"
+        
+        switch info {
+        case .list:
+            return info.description
+        case .object:
+            return info.description
         }
-        if info == Parser.ParseTarget.object {
-            return "객체 데이터"
-        }
-        return "데이터"
     }
-    
 
     func showResult(_ countInfo: CountInfo, _ parseType: Parser.ParseTarget) {
-        print("\(countInfo.countOfJSONData)개 \(selectType(parseType)) 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
+        print("\(countInfo.countOfJSONData)개 \(selectType(parseType)) 데이터 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
     }
     
 }

--- a/JSONParser/JSONParser/OutputVIew.swift
+++ b/JSONParser/JSONParser/OutputVIew.swift
@@ -28,13 +28,22 @@ struct OutputView {
         if info.countOfArray != 0 {
             result.append("배열 \(info.countOfArray)개 ")
         }
-        
         return result
     }
     
+    private func selectType(_ info: CountInfo) -> String {
+        if info.parseType == Parser.ParseTarget.list {
+            return "배열 데이터"
+        }
+        if info.parseType == Parser.ParseTarget.object {
+            return "객체 데이터"
+        }
+        return "데이터"
+    }
     
+
     func showResult(_ countInfo: CountInfo) {
-        print("\(countInfo.countOfJSONData)개 데이터 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
+        print("\(countInfo.countOfJSONData)개 \(selectType(countInfo)) 중에 \(makeResultMessage(countInfo))가 포함되어 있습니다.")
     }
     
 }

--- a/JSONParser/JSONParser/Parser.swift
+++ b/JSONParser/JSONParser/Parser.swift
@@ -13,6 +13,15 @@ struct Parser {
     enum ParseTarget {
         case list
         case object
+        
+        var description: String {
+            switch self {
+            case .list:
+                return "배열"
+            case .object:
+                return "객체"
+            }
+        }
     }
     
     static func matchValues(_ target: (parseValue: [String], parseType: ParseTarget)) throws -> JSONData {

--- a/JSONParser/JSONParser/Parser.swift
+++ b/JSONParser/JSONParser/Parser.swift
@@ -15,9 +15,9 @@ struct Parser {
         case object
     }
     
-    static func matchValues(_ target: ([String], ParseTarget)) throws -> JSONData {
-        let convertTarget = target.0
-        let targetType = target.1
+    static func matchValues(_ target: (parseValue: [String], parseType: ParseTarget)) throws -> JSONData {
+        let convertTarget = target.parseValue
+        let targetType = target.parseType
         
         if targetType == Parser.ParseTarget.list {
             do {

--- a/JSONParser/JSONParser/ValueCounter.swift
+++ b/JSONParser/JSONParser/ValueCounter.swift
@@ -32,6 +32,7 @@ struct ValueCounter {
         var countOfBool = 0
         var countOfString = 0
         var countOfObject = 0
+        var countOfArray = 0
         let countOfJSONData = countTarget.count
         
         for datum in countTarget {
@@ -44,15 +45,15 @@ struct ValueCounter {
                 countOfString += 1
             case .ObjectValue :
                 countOfObject += 1
-            default :
-                countOfString += 0
+            case .ArrayValue :
+                countOfArray += 1
             }
         }
     return CountInfo(countOfInt: countOfInt,
                      countOfBool: countOfBool,
                      countOfString: countOfString,
                      countOfObject: countOfObject,
-                     countOfArray: 0,
+                     countOfArray: countOfArray,
                      countOfJSONData: countOfJSONData)
     }
     

--- a/JSONParser/JSONParser/ValueCounter.swift
+++ b/JSONParser/JSONParser/ValueCounter.swift
@@ -16,7 +16,7 @@ struct ValueCounter {
     }
 
     func makeCountInfo () -> CountInfo {
-        var countInfo = CountInfo()
+        var countInfo = CountInfo(parseType: Parser.ParseTarget.list)
 
         if case let JSONData.ArrayValue(countTarget) = parsedJSONDataList { // enum바인딩
            countInfo = countArrayValues(countTarget)
@@ -54,7 +54,8 @@ struct ValueCounter {
                      countOfString: countOfString,
                      countOfObject: countOfObject,
                      countOfArray: countOfArray,
-                     countOfJSONData: countOfJSONData)
+                     countOfJSONData: countOfJSONData,
+                     parseType: Parser.ParseTarget.list)
     }
     
     private func countObjectValues(_ countTarget: Dictionary<String, JSONData>) -> CountInfo {
@@ -87,7 +88,8 @@ struct ValueCounter {
                          countOfString: countOfString,
                          countOfObject: 0,
                          countOfArray: countOfArray,
-                         countOfJSONData: countOfJSONData)
+                         countOfJSONData: countOfJSONData,
+                         parseType: Parser.ParseTarget.object)
     }
     
 }

--- a/JSONParser/JSONParser/ValueCounter.swift
+++ b/JSONParser/JSONParser/ValueCounter.swift
@@ -16,7 +16,7 @@ struct ValueCounter {
     }
 
     func makeCountInfo () -> CountInfo {
-        var countInfo = CountInfo(parseType: Parser.ParseTarget.list)
+        var countInfo = CountInfo()
 
         if case let JSONData.ArrayValue(countTarget) = parsedJSONDataList { // enum바인딩
            countInfo = countArrayValues(countTarget)
@@ -54,8 +54,7 @@ struct ValueCounter {
                      countOfString: countOfString,
                      countOfObject: countOfObject,
                      countOfArray: countOfArray,
-                     countOfJSONData: countOfJSONData,
-                     parseType: Parser.ParseTarget.list)
+                     countOfJSONData: countOfJSONData)
     }
     
     private func countObjectValues(_ countTarget: Dictionary<String, JSONData>) -> CountInfo {
@@ -88,8 +87,7 @@ struct ValueCounter {
                          countOfString: countOfString,
                          countOfObject: 0,
                          countOfArray: countOfArray,
-                         countOfJSONData: countOfJSONData,
-                         parseType: Parser.ParseTarget.object)
+                         countOfJSONData: countOfJSONData)
     }
     
 }

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -20,11 +20,11 @@ do {
 } catch let error as GrammarChecker.FormatError {
     switch error {
     case .invalidArray:
-        print(GrammarChecker.FormatError.invalidArray.description)
+        print(GrammarChecker.FormatError.invalidArray)
     case .invalidObject:
-        print(GrammarChecker.FormatError.invalidObject.description)
+        print(GrammarChecker.FormatError.invalidObject)
     case .invalidInput:
-        print(GrammarChecker.FormatError.invalidInput.description)
+        print(GrammarChecker.FormatError.invalidInput)
     }
 }
 

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -31,7 +31,7 @@ do {
 let counter = ValueCounter(targetToCount: convertedValues)
 let countInfo = counter.makeCountInfo()
 let outputView = OutputView()
-outputView.showResult(countInfo, parseTarget.parseType)
+outputView.showResultMessage(countInfo, parseTarget.parseType)
 
 
 

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -11,7 +11,7 @@ let inputView = InputView()
 let userInput = inputView.askUserInput()
 
 let grammarChecker = GrammarChecker()
-var parseTarget = ([String](),Parser.ParseTarget.list)
+var parseTarget = (parseValue: [String](), parseType: Parser.ParseTarget.list)
 var convertedValues : JSONData = JSONData.IntegerValue(0)
 
 do {
@@ -31,7 +31,7 @@ do {
 let counter = ValueCounter(targetToCount: convertedValues)
 let countInfo = counter.makeCountInfo()
 let outputView = OutputView()
-outputView.showResult(countInfo)
+outputView.showResult(countInfo, parseTarget.parseType)
 
 
 


### PR DESCRIPTION
- nested array 케이스 로직을 따로 분리하였습니다. 
  - 최초로 입력형태를 검사할땐 배열의 경우 가장 외부의 괄호를 제거하는데, 형변환 타겟인 배열(value로 쓰인 배열)은 괄호가 제거되면 안돼서 로직을 분리했습니다.
  - 중첩 배열 케이스를 추가함에 따라 정규식도 일부 수정하거나 추가했습니다.
- CountInfo에 입력타입(객체 or 배열)을 프로퍼티로 두어 OutputView에 전달하고, 케이스에 따라 결과 메시지를 출력할 수 있도록 했습니다.