### PR TITLE
Jsonparser step5

### DIFF
--- a/JSONParser/JSONParser/Formatter.swift
+++ b/JSONParser/JSONParser/Formatter.swift
@@ -71,17 +71,17 @@ struct Formatter {
                 throw err
             }
         }else if json is JSONObject {
-            var object:[String:JSONValueType] = [:]
+            var objects:[[String:JSONValueType]] = []
             for token in tokens {
                 guard let pair = extractPair(from: token) else { throw JSONParserError.invalidFormat }
                 do {
                     let validJSONValueTypes = try generateJSONValue(from: [pair.value])
-                    object[pair.key] = validJSONValueTypes[0]
+                    objects.append([pair.key:validJSONValueTypes[0]])
                 } catch let err {
                     throw err
                 }
             }
-            json.values = [JSONValueType.object(object)]
+            json.values = [JSONValueType.object(objects)]
         }
         
         return json
@@ -169,8 +169,8 @@ struct Formatter {
     }
     
     // 토큰의 형식이 객체 형식이라면 JSONValue.object로 wrapping하기 위해 가공
-    private static func generateObject(from target: String) throws -> [String:JSONValueType] {
-        var values: [String:JSONValueType] = [:]
+    private static func generateObject(from target: String) throws -> [[String:JSONValueType]] {
+        var values: [[String:JSONValueType]] = []
         var value = ""
         var isString = false
         var isKey = false
@@ -189,7 +189,7 @@ struct Formatter {
                     value += String(character)  // 문자열의 일부면 추가
                 }else {
                     do {
-                        values[key] = try wrapUp(with: value)
+                        values.append([key: try wrapUp(with: value)])
                         value = ""              // 초기화
                         key = ""
                     }catch let err {
@@ -208,8 +208,9 @@ struct Formatter {
                     value += String(character)  // 문자열의 일부면 추가
                 }else {
                     do {
-                        values[key] = try wrapUp(with: value)
+                        values.append([key: try wrapUp(with: value)])
                         value = ""
+                        key = ""
                     } catch let err {
                         throw err
                     }

--- a/JSONParser/JSONParser/JSONType.swift
+++ b/JSONParser/JSONParser/JSONType.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 protocol JSONType {
+    var text: String { get }
     var values: JSONValueType { set get }
     var prefix: String { get }
     var result: (string:Int, int:Int, bool:Int, object: Int, array: Int) { get }
 }
-
 
 enum JSONValueType {
     case string(String)
@@ -23,8 +23,89 @@ enum JSONValueType {
     case array([JSONValueType])
 }
 
+class PrettyJSONDiscripter {
+    var stageOfArray: Int = 0
+    var stageOfObject: Int = 0
+    
+    func presentArray(from array: [JSONValueType]) -> String {
+        let stage = stageOfArray > 1 ? stageOfArray - 1 : stageOfArray
+        var text = "\(stageOfArray > 0 ? "\n" : "")\(tab(at: stage))["
+        for (index, element) in array.enumerated() {
+            
+            switch element {
+            case .array(_), .object(_):
+                stageOfArray += 1
+            default: break
+            }
+            
+            text += presentValue(from: element)
+            if index != array.count - 1 {
+                text += ","
+            }
+        }
+        text += "]\(stageOfArray > 0 ? "\n" : "")"
+        return text
+    }
+    
+    func presentObject(from objects: [[String:JSONValueType]]) -> String {
+        stageOfObject += 1
+        let currentStage = stageOfObject + stageOfArray
+        
+        var text = "{"
+        for (index, object) in objects.enumerated() {
+            text += presentPair(from: object, stage: currentStage)
+            
+            if index != objects.count - 1 {
+                text += ","
+            }
+        }
+        
+        text += "\n\(tab(at: currentStage - 1))}"
+        
+        return text
+    }
+    
+    func presentPair(from pair: [String:JSONValueType], stage: Int) -> String {
+        var text = ""
+        let keys = pair.keys.map {String($0)}
+        let values = pair.values.map {$0}
+        
+        text += "\n\(tab(at: stage))\(keys[0]) : \(presentValue(from: values[0]))"
+        return text
+    }
+    
+    func presentValue(from value: JSONValueType) -> String {
+        switch value {
+        case .string(let stringValue):
+            return stringValue
+        case .int(let integerValue):
+            return "\(integerValue)"
+        case .bool(let booleanValue):
+            return "\(booleanValue)"
+        case .object(let objectValue):
+            return presentObject(from: objectValue)
+        case .array(let arrayValue):
+            return presentArray(from: arrayValue)
+        }
+    }
+    
+    func tab(at stage: Int) -> String {
+        if stage <= 0 {
+            return ""
+        }
+        
+        var tabs = ""
+        
+        for _ in (0..<stage) {
+            tabs += "\t"
+        }
+        
+        return tabs
+    }
 
-struct JSONArray: JSONType {
+}
+
+class JSONArray: PrettyJSONDiscripter, JSONType {
     var prefix: String {
         return "배열안에는"
     }
@@ -59,12 +140,16 @@ struct JSONArray: JSONType {
         return (string, int, bool, object, array)
     }
     
+    lazy var text: String = {
+        return presentValue(from: values)
+    }()
+    
     init(values: JSONValueType) {
         self.values = values
     }
 }
 
-struct JSONObject: JSONType {
+class JSONObject: PrettyJSONDiscripter, JSONType {
     var prefix: String {
         return "객체안에는"
     }
@@ -99,6 +184,10 @@ struct JSONObject: JSONType {
         // 단일 객체이므로 객체의 값은 0으로 반환
         return (string, int, bool, object, array)
     }
+    
+    lazy var text: String = {
+        return presentValue(from: values)
+    }()
     
     init(values: JSONValueType) {
         self.values = values

--- a/JSONParser/JSONParser/JSONType.swift
+++ b/JSONParser/JSONParser/JSONType.swift
@@ -21,73 +21,26 @@ enum JSONValueType {
     case bool(Bool)
     case object([[String:JSONValueType]])
     case array([JSONValueType])
+    
+    func presentableValue(stage: Int) -> String {
+        switch self {
+        case .string(let stringValue):
+            return stringValue
+        case .int(let intValue):
+            return "\(intValue)"
+        case .bool(let boolValue):
+            return "\(boolValue)"
+        case .array(let array):
+            let json = JSONArray(values: self)
+            return json.presentArray(from: array, stage: stage)
+        case .object(let object):
+            let json = JSONObject(values: self)
+            return json.presentObject(from: object, stage: stage)
+        }
+    }
 }
 
 class PrettyJSONDiscripter {
-    var stageOfArray: Int = 0
-    var stageOfObject: Int = 0
-    
-    func presentArray(from array: [JSONValueType]) -> String {
-        let stage = stageOfArray > 1 ? stageOfArray - 1 : stageOfArray
-        var text = "\(stageOfArray > 0 ? "\n" : "")\(tab(at: stage))["
-        for (index, element) in array.enumerated() {
-            
-            switch element {
-            case .array(_), .object(_):
-                stageOfArray += 1
-            default: break
-            }
-            
-            text += presentValue(from: element)
-            if index != array.count - 1 {
-                text += ","
-            }
-        }
-        text += "]\(stageOfArray > 0 ? "\n" : "")"
-        return text
-    }
-    
-    func presentObject(from objects: [[String:JSONValueType]]) -> String {
-        stageOfObject += 1
-        let currentStage = stageOfObject + stageOfArray
-        
-        var text = "{"
-        for (index, object) in objects.enumerated() {
-            text += presentPair(from: object, stage: currentStage)
-            
-            if index != objects.count - 1 {
-                text += ","
-            }
-        }
-        
-        text += "\n\(tab(at: currentStage - 1))}"
-        
-        return text
-    }
-    
-    func presentPair(from pair: [String:JSONValueType], stage: Int) -> String {
-        var text = ""
-        let keys = pair.keys.map {String($0)}
-        let values = pair.values.map {$0}
-        
-        text += "\n\(tab(at: stage))\(keys[0]) : \(presentValue(from: values[0]))"
-        return text
-    }
-    
-    func presentValue(from value: JSONValueType) -> String {
-        switch value {
-        case .string(let stringValue):
-            return stringValue
-        case .int(let integerValue):
-            return "\(integerValue)"
-        case .bool(let booleanValue):
-            return "\(booleanValue)"
-        case .object(let objectValue):
-            return presentObject(from: objectValue)
-        case .array(let arrayValue):
-            return presentArray(from: arrayValue)
-        }
-    }
     
     func tab(at stage: Int) -> String {
         if stage <= 0 {
@@ -141,11 +94,31 @@ class JSONArray: PrettyJSONDiscripter, JSONType {
     }
     
     lazy var text: String = {
-        return presentValue(from: values)
+        let stage = result.int > 0 || result.bool > 0 || result.int > 0 ? 0 : 1
+        return values.presentableValue(stage: stage)
     }()
     
     init(values: JSONValueType) {
         self.values = values
+    }
+    
+    func presentArray(from array: [JSONValueType], stage: Int) -> String {
+        var text = "["
+        for (index, item) in array.enumerated() {
+            switch item {
+            case .array(_):
+                text += "\(stage > 0 ? "\n" : "")\(tab(at: stage))\(item.presentableValue(stage: stage + 1))\(stage > 0 ? "\n" : "")"
+            case .object(_):
+                text += "\(item.presentableValue(stage: stage + 1))"
+            default:
+                text += item.presentableValue(stage: stage)
+            }
+            if index != array.count - 1 {
+                text += ","
+            }
+        }
+        text += "]"
+        return text
     }
 }
 
@@ -186,10 +159,38 @@ class JSONObject: PrettyJSONDiscripter, JSONType {
     }
     
     lazy var text: String = {
-        return presentValue(from: values)
+        return values.presentableValue(stage: 1)
     }()
     
     init(values: JSONValueType) {
         self.values = values
+    }
+    
+    func presentObject(from objects: [[String:JSONValueType]], stage: Int) -> String {
+        var text = "{\n"
+        for (index, pair) in objects.enumerated() {
+            let pairString = presentPair(from: pair, stage: stage)
+            text += pairString
+            if index != objects.count - 1 {
+                text += ","
+            }
+            text += "\n"
+        }
+        text += "\(tab(at: stage == 1 ? 0 : stage - 1))}"
+        return text
+    }
+    
+    func presentPair(from pair: [String:JSONValueType], stage: Int) -> String {
+        var text = ""
+        let keys = pair.keys.map {String($0)}
+        let values = pair.values.map {$0}
+        
+        switch values[0] {
+        case .array(_), .object(_):
+            text += "\(tab(at: stage))\(keys[0]) : \(values[0].presentableValue(stage: stage + 1))"
+        default:
+            text += "\(tab(at: stage))\(keys[0]) : \(values[0].presentableValue(stage: stage))"
+        }
+        return text
     }
 }

--- a/JSONParser/JSONParser/JSONType.swift
+++ b/JSONParser/JSONParser/JSONType.swift
@@ -19,7 +19,7 @@ enum JSONValueType {
     case string(String)
     case int(Int)
     case bool(Bool)
-    case object([String:JSONValueType])
+    case object([[String:JSONValueType]])
     case array([JSONValueType])
 }
 
@@ -70,9 +70,10 @@ struct JSONObject: JSONType {
         var array = 0
         
         switch values[0] {
-        case .object(let jsonObject):
-            jsonObject.values.forEach { (type) in
-                switch type {
+        case .object(let objects):
+            objects.forEach {
+                let objectValues = $0.values.map {$0}
+                switch objectValues[0] {
                 case .string(_):
                     string += 1
                 case .int(_):

--- a/JSONParser/JSONParser/JSONType.swift
+++ b/JSONParser/JSONParser/JSONType.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol JSONType {
-    var values: [JSONValueType] { set get }
+    var values: JSONValueType { set get }
     var prefix: String { get }
     var result: (string:Int, int:Int, bool:Int, object: Int, array: Int) { get }
 }
@@ -28,7 +28,7 @@ struct JSONArray: JSONType {
     var prefix: String {
         return "배열안에는"
     }
-    var values: [JSONValueType] = []
+    var values: JSONValueType
     
     var result: (string: Int, int: Int, bool: Int, object: Int, array: Int) {
         var string = 0
@@ -37,22 +37,30 @@ struct JSONArray: JSONType {
         var object = 0
         var array = 0
         
-        values.forEach {
-            switch $0 {
-            case .string(_):
-                string += 1
-            case .int(_):
-                int += 1
-            case .bool(_):
-                bool += 1
-            case .object(_):
-                object += 1
-            case .array(_):
-                array += 1
+        switch values {
+        case .array(let jsonValues):
+            jsonValues.forEach {
+                switch $0 {
+                case .string(_):
+                    string += 1
+                case .int(_):
+                    int += 1
+                case .bool(_):
+                    bool += 1
+                case .object(_):
+                    object += 1
+                case .array(_):
+                    array += 1
+                }
             }
+        default: break
         }
         
         return (string, int, bool, object, array)
+    }
+    
+    init(values: JSONValueType) {
+        self.values = values
     }
 }
 
@@ -60,7 +68,7 @@ struct JSONObject: JSONType {
     var prefix: String {
         return "객체안에는"
     }
-    var values: [JSONValueType] = []
+    var values: JSONValueType
     
     var result: (string: Int, int: Int, bool: Int, object: Int, array: Int) {
         var string = 0
@@ -69,7 +77,7 @@ struct JSONObject: JSONType {
         var object = 0
         var array = 0
         
-        switch values[0] {
+        switch values {
         case .object(let objects):
             objects.forEach {
                 let objectValues = $0.values.map {$0}
@@ -90,5 +98,9 @@ struct JSONObject: JSONType {
         }
         // 단일 객체이므로 객체의 값은 0으로 반환
         return (string, int, bool, object, array)
+    }
+    
+    init(values: JSONValueType) {
+        self.values = values
     }
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -14,15 +14,15 @@ struct OutputView {
     private static var stageOfArray: Int = 0
     
     static func display(_ values: JSONType){
-        print(text(from: values))
-        print(presentResult(of: values))
+        print(presentResult(from: values))
+        print(values.text)
     }
     
     static func display(_ error: JSONParserError) {
         print(error)
     }
     
-    private static func text(from value: JSONType) -> String {
+    private static func presentResult(from value: JSONType) -> String {
         var text = ""
         let result = value.result
         text += value.prefix
@@ -50,85 +50,6 @@ struct OutputView {
         text += "가 존재합니다."
         
         return text
-    }
-    
-    private static func presentResult(of json: JSONType) -> String {
-        return presentValue(from: json.values)
-    }
-    
-    private static func presentArray(from array: [JSONValueType]) -> String {
-        var text = "\(stageOfArray > 0 ? "\n" : "")\(tab(at: stageOfArray - 1))["
-        for (index, element) in array.enumerated() {
-            
-            switch element {
-            case .array(_), .object(_):
-                stageOfArray += 1
-            default: break
-            }
-            
-            text += presentValue(from: element)
-            if index != array.count - 1 {
-                text += ","
-            }
-        }
-        text += "]\(stageOfArray > 0 ? "\n" : "")"
-        return text
-    }
-    
-    private static func presentObject(from objects: [[String:JSONValueType]]) -> String {
-        stageOfObject += 1
-        let currentStage = stageOfObject + stageOfArray
-        
-        var text = "{"
-        for (index, object) in objects.enumerated() {
-            text += presentPair(from: object, stage: currentStage)
-            
-            if index != objects.count - 1 {
-                text += ","
-            }
-        }
-        
-        text += "\n\(tab(at: currentStage - 1))}"
-        
-        return text
-    }
-    
-    private static func presentPair(from pair: [String:JSONValueType], stage: Int) -> String {
-        var text = ""
-        let keys = pair.keys.map {String($0)}
-        let values = pair.values.map {$0}
-        
-        text += "\n\(tab(at: stage))\(keys[0]) : \(presentValue(from: values[0]))"
-        return text
-    }
-    
-    private static func presentValue(from value: JSONValueType) -> String {
-        switch value {
-        case .string(let stringValue):
-            return stringValue
-        case .int(let integerValue):
-            return "\(integerValue)"
-        case .bool(let booleanValue):
-            return "\(booleanValue)"
-        case .object(let objectValue):
-            return presentObject(from: objectValue)
-        case .array(let arrayValue):
-            return presentArray(from: arrayValue)
-        }
-    }
-    
-    private static func tab(at stage: Int) -> String {
-        if stage < 0 {
-            return ""
-        }
-        
-        var tabs = ""
-        
-        for _ in (0..<stage) {
-            tabs += "\t"
-        }
-        
-        return tabs
     }
 }
 

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -10,7 +10,8 @@ import Foundation
 
 struct OutputView {
     
-    private static var stage: Int = 0
+    private static var stageOfObject: Int = 0
+    private static var stageOfArray: Int = 0
     
     static func display(_ values: JSONType){
         print(text(from: values))
@@ -62,20 +63,27 @@ struct OutputView {
     }
     
     private static func presentArray(from array: [JSONValueType]) -> String {
-        var text = "["
+        var text = "\(stageOfArray > 0 ? "\n" : "")\(tab(at: stageOfArray - 1))["
         for (index, element) in array.enumerated() {
+            
+            switch element {
+            case .array(_), .object(_):
+                stageOfArray += 1
+            default: break
+            }
+            
             text += presentValue(from: element)
             if index != array.count - 1 {
                 text += ","
             }
         }
-        text += "]"
+        text += "]\(stageOfArray > 0 ? "\n" : "")"
         return text
     }
     
     private static func presentObject(from objects: [[String:JSONValueType]]) -> String {
-        stage += 1
-        let currentStage = stage
+        stageOfObject += 1
+        let currentStage = stageOfObject + stageOfArray
         
         var text = "{"
         for (index, object) in objects.enumerated() {

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -53,13 +53,7 @@ struct OutputView {
     }
     
     private static func presentResult(of json: JSONType) -> String {
-        if json is JSONObject {
-            let object = json.values[0]
-            return presentValue(from: object)
-        }
-        
-        let array = json.values
-        return presentArray(from: array)
+        return presentValue(from: json.values)
     }
     
     private static func presentArray(from array: [JSONValueType]) -> String {

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -52,15 +52,25 @@ struct OutputView {
     }
     
     private static func presentResult(of json: JSONType) -> String {
-        var text = ""
         if json is JSONObject {
             let object = json.values[0]
             return presentValue(from: object)
         }
         
         let array = json.values
-        
-        return ""
+        return presentArray(from: array)
+    }
+    
+    private static func presentArray(from array: [JSONValueType]) -> String {
+        var text = "["
+        for (index, element) in array.enumerated() {
+            text += presentValue(from: element)
+            if index != array.count - 1 {
+                text += ","
+            }
+        }
+        text += "]"
+        return text
     }
     
     private static func presentObject(from objects: [[String:JSONValueType]]) -> String {
@@ -101,7 +111,7 @@ struct OutputView {
         case .object(let objectValue):
             return presentObject(from: objectValue)
         case .array(let arrayValue):
-            return "array"
+            return presentArray(from: arrayValue)
         }
     }
     

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -10,8 +10,11 @@ import Foundation
 
 struct OutputView {
     
+    private static var stage: Int = 0
+    
     static func display(_ values: JSONType){
         print(text(from: values))
+        print(presentResult(of: values))
     }
     
     static func display(_ error: JSONParserError) {
@@ -46,6 +49,74 @@ struct OutputView {
         text += "가 존재합니다."
         
         return text
+    }
+    
+    private static func presentResult(of json: JSONType) -> String {
+        var text = ""
+        if json is JSONObject {
+            let object = json.values[0]
+            return presentValue(from: object)
+        }
+        
+        let array = json.values
+        
+        return ""
+    }
+    
+    private static func presentObject(from objects: [[String:JSONValueType]]) -> String {
+        stage += 1
+        let currentStage = stage
+        
+        var text = "{"
+        for (index, object) in objects.enumerated() {
+            text += presentPair(from: object, stage: currentStage)
+            
+            if index != objects.count - 1 {
+                text += ","
+            }
+        }
+        
+        text += "\n\(tab(at: currentStage - 1))}"
+        
+        return text
+    }
+    
+    private static func presentPair(from pair: [String:JSONValueType], stage: Int) -> String {
+        var text = ""
+        let keys = pair.keys.map {String($0)}
+        let values = pair.values.map {$0}
+        
+        text += "\n\(tab(at: stage))\(keys[0]) : \(presentValue(from: values[0]))"
+        return text
+    }
+    
+    private static func presentValue(from value: JSONValueType) -> String {
+        switch value {
+        case .string(let stringValue):
+            return stringValue
+        case .int(let integerValue):
+            return "\(integerValue)"
+        case .bool(let booleanValue):
+            return "\(booleanValue)"
+        case .object(let objectValue):
+            return presentObject(from: objectValue)
+        case .array(let arrayValue):
+            return "array"
+        }
+    }
+    
+    private static func tab(at stage: Int) -> String {
+        if stage < 0 {
+            return ""
+        }
+        
+        var tabs = ""
+        
+        for _ in (0..<stage) {
+            tabs += "\t"
+        }
+        
+        return tabs
     }
 }
 


### PR DESCRIPTION
5단계 진행하였습니다. 
**기존 코드와의 차이점**
1. `JSONValueType`의 객체 case `.object([String:JSONValueType])` 에서 키-값 순서를 보장하기 위해 `.object([[String:JSONValueType]]`으로 변경
