### PR TITLE
JSON 문자열 분석기 1단계 - 단순 List 분석

### DIFF
--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		83AE2E101F8CAC2800F38CC9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AE2E0F1F8CAC2800F38CC9 /* main.swift */; };
+		A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F8E21786A2C0044CFD9 /* InputView.swift */; };
+		A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9021786A3D0044CFD9 /* OutputView.swift */; };
+		A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F92217872D20044CFD9 /* Extensions.swift */; };
+		A3D86F952178749B0044CFD9 /* JSONGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F942178749B0044CFD9 /* JSONGenerator.swift */; };
+		A3D86F9721787C7C0044CFD9 /* TypeInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,6 +30,11 @@
 /* Begin PBXFileReference section */
 		83AE2E0C1F8CAC2800F38CC9 /* JSONParser */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = JSONParser; sourceTree = BUILT_PRODUCTS_DIR; };
 		83AE2E0F1F8CAC2800F38CC9 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		A3D86F8E21786A2C0044CFD9 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
+		A3D86F9021786A3D0044CFD9 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
+		A3D86F92217872D20044CFD9 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		A3D86F942178749B0044CFD9 /* JSONGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONGenerator.swift; sourceTree = "<group>"; };
+		A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeInspector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +68,11 @@
 			isa = PBXGroup;
 			children = (
 				83AE2E0F1F8CAC2800F38CC9 /* main.swift */,
+				A3D86F8E21786A2C0044CFD9 /* InputView.swift */,
+				A3D86F9021786A3D0044CFD9 /* OutputView.swift */,
+				A3D86F92217872D20044CFD9 /* Extensions.swift */,
+				A3D86F942178749B0044CFD9 /* JSONGenerator.swift */,
+				A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */,
 			);
 			path = JSONParser;
 			sourceTree = "<group>";
@@ -121,6 +136,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				83AE2E101F8CAC2800F38CC9 /* main.swift in Sources */,
+				A3D86F9721787C7C0044CFD9 /* TypeInspector.swift in Sources */,
+				A3D86F952178749B0044CFD9 /* JSONGenerator.swift in Sources */,
+				A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */,
+				A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */,
+				A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F92217872D20044CFD9 /* Extensions.swift */; };
 		A3D86F952178749B0044CFD9 /* JSONGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F942178749B0044CFD9 /* JSONGenerator.swift */; };
 		A3D86F9721787C7C0044CFD9 /* TypeInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */; };
+		A3D86F9F2179AB2A0044CFD9 /* UnitTestJSONGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9E2179AB2A0044CFD9 /* UnitTestJSONGenerator.swift */; };
+		A3D86FA42179AB610044CFD9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F92217872D20044CFD9 /* Extensions.swift */; };
+		A3D86FA52179AB680044CFD9 /* JSONGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F942178749B0044CFD9 /* JSONGenerator.swift */; };
+		A3D86FA62179AB6C0044CFD9 /* TypeInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */; };
+		A3D86FA82179ABB40044CFD9 /* UnitTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */; };
+		A3D86FAA2179ABC50044CFD9 /* UnitTestTypeInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86FA92179ABC50044CFD9 /* UnitTestTypeInspector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -35,10 +41,22 @@
 		A3D86F92217872D20044CFD9 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A3D86F942178749B0044CFD9 /* JSONGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONGenerator.swift; sourceTree = "<group>"; };
 		A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeInspector.swift; sourceTree = "<group>"; };
+		A3D86F9C2179AB2A0044CFD9 /* JSONParserUnitTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JSONParserUnitTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A3D86F9E2179AB2A0044CFD9 /* UnitTestJSONGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestJSONGenerator.swift; sourceTree = "<group>"; };
+		A3D86FA02179AB2A0044CFD9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestExtensions.swift; sourceTree = "<group>"; };
+		A3D86FA92179ABC50044CFD9 /* UnitTestTypeInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestTypeInspector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		83AE2E091F8CAC2800F38CC9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A3D86F992179AB2A0044CFD9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -52,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				83AE2E0E1F8CAC2800F38CC9 /* JSONParser */,
+				A3D86F9D2179AB2A0044CFD9 /* JSONParserUnitTest */,
 				83AE2E0D1F8CAC2800F38CC9 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -60,6 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				83AE2E0C1F8CAC2800F38CC9 /* JSONParser */,
+				A3D86F9C2179AB2A0044CFD9 /* JSONParserUnitTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -75,6 +95,17 @@
 				A3D86F9621787C7C0044CFD9 /* TypeInspector.swift */,
 			);
 			path = JSONParser;
+			sourceTree = "<group>";
+		};
+		A3D86F9D2179AB2A0044CFD9 /* JSONParserUnitTest */ = {
+			isa = PBXGroup;
+			children = (
+				A3D86F9E2179AB2A0044CFD9 /* UnitTestJSONGenerator.swift */,
+				A3D86FA02179AB2A0044CFD9 /* Info.plist */,
+				A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */,
+				A3D86FA92179ABC50044CFD9 /* UnitTestTypeInspector.swift */,
+			);
+			path = JSONParserUnitTest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -97,18 +128,39 @@
 			productReference = 83AE2E0C1F8CAC2800F38CC9 /* JSONParser */;
 			productType = "com.apple.product-type.tool";
 		};
+		A3D86F9B2179AB2A0044CFD9 /* JSONParserUnitTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A3D86FA12179AB2A0044CFD9 /* Build configuration list for PBXNativeTarget "JSONParserUnitTest" */;
+			buildPhases = (
+				A3D86F982179AB2A0044CFD9 /* Sources */,
+				A3D86F992179AB2A0044CFD9 /* Frameworks */,
+				A3D86F9A2179AB2A0044CFD9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JSONParserUnitTest;
+			productName = JSONParserUnitTest;
+			productReference = A3D86F9C2179AB2A0044CFD9 /* JSONParserUnitTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		83AE2E041F8CAC2800F38CC9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0900;
+				LastSwiftUpdateCheck = 1000;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = JK;
 				TargetAttributes = {
 					83AE2E0B1F8CAC2800F38CC9 = {
 						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
+					A3D86F9B2179AB2A0044CFD9 = {
+						CreatedOnToolsVersion = 10.0;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -126,9 +178,20 @@
 			projectRoot = "";
 			targets = (
 				83AE2E0B1F8CAC2800F38CC9 /* JSONParser */,
+				A3D86F9B2179AB2A0044CFD9 /* JSONParserUnitTest */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A3D86F9A2179AB2A0044CFD9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		83AE2E081F8CAC2800F38CC9 /* Sources */ = {
@@ -141,6 +204,19 @@
 				A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */,
 				A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */,
 				A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A3D86F982179AB2A0044CFD9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3D86FA52179AB680044CFD9 /* JSONGenerator.swift in Sources */,
+				A3D86FAA2179ABC50044CFD9 /* UnitTestTypeInspector.swift in Sources */,
+				A3D86FA82179ABB40044CFD9 /* UnitTestExtensions.swift in Sources */,
+				A3D86F9F2179AB2A0044CFD9 /* UnitTestJSONGenerator.swift in Sources */,
+				A3D86FA42179AB610044CFD9 /* Extensions.swift in Sources */,
+				A3D86FA62179AB6C0044CFD9 /* TypeInspector.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -271,6 +347,43 @@
 			};
 			name = Release;
 		};
+		A3D86FA22179AB2A0044CFD9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = JSONParserUnitTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.jamie.JSONParserUnitTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		A3D86FA32179AB2A0044CFD9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = JSONParserUnitTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.jamie.JSONParserUnitTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -288,6 +401,15 @@
 			buildConfigurations = (
 				83AE2E141F8CAC2800F38CC9 /* Debug */,
 				83AE2E151F8CAC2800F38CC9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A3D86FA12179AB2A0044CFD9 /* Build configuration list for PBXNativeTarget "JSONParserUnitTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A3D86FA22179AB2A0044CFD9 /* Debug */,
+				A3D86FA32179AB2A0044CFD9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JSONParser/JSONParser.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JSONParser/JSONParser.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/JSONParser/JSONParser/Extensions.swift
+++ b/JSONParser/JSONParser/Extensions.swift
@@ -15,6 +15,9 @@ extension String {
     func hasSideSquareBrackets() -> Bool {
         return (self.count > 1 && self.first == "[" && self.last == "]")
     }
+    func hasDoubleQuotation() -> Bool {
+        return (self.count > 1 && self.first == "\"" && self.last == self.first)
+    }
     func trimSquareBrackets() -> String {
         return self.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
     }

--- a/JSONParser/JSONParser/Extensions.swift
+++ b/JSONParser/JSONParser/Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  Extensions.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 18/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func removeWhiteSpaces() -> String {
+        return self.components(separatedBy: .whitespaces).joined()
+    }
+    func trimSquareBrackets() -> String {
+        return self.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+    }
+    func trimDoubleQuotation() -> String {
+        return self.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+    func splitByComma() -> [String] {
+        return self.split(separator: ",").map({ String($0) })
+    }
+}

--- a/JSONParser/JSONParser/Extensions.swift
+++ b/JSONParser/JSONParser/Extensions.swift
@@ -12,6 +12,9 @@ extension String {
     func removeWhiteSpaces() -> String {
         return self.components(separatedBy: .whitespaces).joined()
     }
+    func hasSideSquareBrackets() -> Bool {
+        return (self.count > 1 && self.first == "[" && self.last == "]")
+    }
     func trimSquareBrackets() -> String {
         return self.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
     }

--- a/JSONParser/JSONParser/InputView.swift
+++ b/JSONParser/JSONParser/InputView.swift
@@ -1,0 +1,19 @@
+//
+//  InputView.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 18/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct InputView {
+    static private let guideMessage = "분석할 JSON 데이터를 입력하세요."
+    
+    static func readInput() -> String {
+        print(guideMessage)
+        guard let input: String = readLine() else { return String() }
+        return input
+    }
+}

--- a/JSONParser/JSONParser/JSONGenerator.swift
+++ b/JSONParser/JSONParser/JSONGenerator.swift
@@ -9,5 +9,10 @@
 import Foundation
 
 struct JSONGenerator {
-    static let stringArray = { (jsonString: String) -> [String] in return jsonString.removeWhiteSpaces().trimSquareBrackets().splitByComma() }
+    private static let stringArray = { (jsonString: String) -> [String] in return jsonString.removeWhiteSpaces().trimSquareBrackets().splitByComma() }
+    
+    static func extractStringArray(from jsonString: String) -> [String]? {
+        guard jsonString.hasSideSquareBrackets() else { return nil }
+        return stringArray(jsonString)
+    }
 }

--- a/JSONParser/JSONParser/JSONGenerator.swift
+++ b/JSONParser/JSONParser/JSONGenerator.swift
@@ -1,0 +1,13 @@
+//
+//  JSONGenerator.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 18/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct JSONGenerator {
+    static let stringArray = { (jsonString: String) -> [String] in return jsonString.removeWhiteSpaces().trimSquareBrackets().splitByComma() }
+}

--- a/JSONParser/JSONParser/JSONGenerator.swift
+++ b/JSONParser/JSONParser/JSONGenerator.swift
@@ -11,8 +11,24 @@ import Foundation
 struct JSONGenerator {
     private static let stringArray = { (jsonString: String) -> [String] in return jsonString.removeWhiteSpaces().trimSquareBrackets().splitByComma() }
     
-    static func extractStringArray(from jsonString: String) -> [String]? {
+    private static func extractStringArray(from jsonString: String) -> [String]? {
         guard jsonString.hasSideSquareBrackets() else { return nil }
         return stringArray(jsonString)
+    }
+    
+    private static func typeCast(from string: String) -> Any? {
+        guard string.hasDoubleQuotation() == false else { return string.trimDoubleQuotation() }
+        guard Int(string) == nil else { return Int(string) }
+        guard Bool(string) == nil else { return Bool(string) }
+        return nil
+    }
+    
+    static func makeJSONArray(from jsonString: String) -> [Any?]? {
+        guard let stringArray = extractStringArray(from: jsonString) else { return nil }
+        var anyArray = [Any?]()
+        for string in stringArray {
+            anyArray.append(typeCast(from: string))
+        }
+        return anyArray
     }
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,11 +9,30 @@
 import Foundation
 
 struct OutputView {
+    private static func countType(in stringArray: [String]) -> [Int] {
+        var typeCount = [Int]()
+        typeCount.append(StringInspector.countType(in: stringArray))
+        typeCount.append(DoubleInspector.countType(in: stringArray))
+        typeCount.append(BooleanInspector.countType(in: stringArray))
+        return typeCount
+    }
+    
+    private static func addTypeName(in stringArray: [String]) -> String {
+        var typeName: [String?] = ["문자열", "숫자", "부울"]
+        let typeCount = countType(in: stringArray)
+        for index in 0..<3 {
+            if (typeCount[index]==0) {
+                typeName[index] = nil
+                continue
+            }
+            typeName[index]?.append(" \(typeCount[index])개")
+        }
+        return typeName.compactMap({$0}).joined(separator: ", ")
+    }
+    
     static func showTypeCountOf(JSON stringArray: [String]) {
         let totalCount = stringArray.count
-        let stringCout = StringInspector.countType(in: stringArray)
-        let doubleCount = DoubleInspector.countType(in: stringArray)
-        let boolCount = BooleanInspector.countType(in: stringArray)
-        print("총 \(totalCount)개의 데이터 중에 문자열 \(stringCout)개, 숫자 \(doubleCount)개, 부울 \(boolCount)개가 포함되어 있습니다.")
+        let typeCount = addTypeName(in: stringArray)
+        print("총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다.")
     }
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -8,35 +8,32 @@
 
 import Foundation
 
-struct Message {
-    static let invalidForm = "지원하는 규격이 아닙니다."
-    
-    struct countResult {
-        static let string = "문자열"
-        static let int = "숫자"
-        static let bool = "부울"
-        static let noCount = 0
-        static let countUnit = "개"
-        static let comma = ","
-        static func makeSentence(with totalCount: Int, and typeCount: String) -> String {
-            return "총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다."
+struct OutputView {
+    private struct Message {
+        static let invalidForm = "지원하는 규격이 아닙니다."
+        
+        struct countResult {
+            static let noCount = 0
+            static let countUnit = "개"
+            static let comma = ","
+            static func makeSentence(with totalCount: Int, and typeCount: String) -> String {
+                return "총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다."
+            }
         }
     }
-}
-
-struct OutputView {
+    
     private static func addTypeName(to jsonArray: [Any?]) -> String {
-        var typeName: [String?] = [Message.countResult.string, Message.countResult.int, Message.countResult.bool]
+        var typeNames: [String?] = [typeName.string.rawValue, typeName.int.rawValue, typeName.bool.rawValue]
         let typeCount = TypeInspector.countType(of: jsonArray)
-        for index in 0..<typeName.count {
-            let key = typeName[index] ?? ""
+        for index in 0..<typeNames.count {
+            let key = typeNames[index] ?? typeName.none.rawValue
             guard let count = typeCount[key] else {
-                typeName[index] = nil
+                typeNames[index] = nil
                 continue
             }
-            typeName[index]?.append(" \(count)\(Message.countResult.countUnit)")
+            typeNames[index]?.append(" \(count)\(Message.countResult.countUnit)")
         }
-        return typeName.compactMap({$0}).joined(separator: "\(Message.countResult.comma) ")
+        return typeNames.compactMap({$0}).joined(separator: "\(Message.countResult.comma) ")
     }
     
     static func showTypeCountOf(JSON jsonArray: [Any?]) {

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct OutputView {
     private struct Message {
-        static let invalidJSON = "JSON 규격이 아닙니다."
+        static let invalidForm = "지원하는 규격이 아닙니다."
         
         struct countResult {
             static let typeString = "문자열"
@@ -53,6 +53,6 @@ struct OutputView {
     }
     
     static func notifyIssue() {
-        print(Message.invalidJSON)
+        print(Message.invalidForm)
     }
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,6 +9,22 @@
 import Foundation
 
 struct OutputView {
+    private struct Message {
+        static let invalidJSON = "JSON 규격이 아닙니다."
+        
+        struct countResult {
+            static let typeString = "문자열"
+            static let typeDouble = "숫자"
+            static let typeBool = "부울"
+            static let noCount = 0
+            static let countUnit = "개"
+            static let comma = ","
+            static func makeSentence(with totalCount: Int, and typeCount: String) -> String {
+                return "총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다."
+            }
+        }
+    }
+    
     private static func countType(in stringArray: [String]) -> [Int] {
         var typeCount = [Int]()
         typeCount.append(StringInspector.countType(in: stringArray))
@@ -18,21 +34,25 @@ struct OutputView {
     }
     
     private static func addTypeName(in stringArray: [String]) -> String {
-        var typeName: [String?] = ["문자열", "숫자", "부울"]
+        var typeName: [String?] = [Message.countResult.typeString, Message.countResult.typeDouble, Message.countResult.typeBool]
         let typeCount = countType(in: stringArray)
-        for index in 0..<3 {
-            if (typeCount[index]==0) {
+        for index in 0..<typeName.count {
+            if (typeCount[index] == Message.countResult.noCount) {
                 typeName[index] = nil
                 continue
             }
-            typeName[index]?.append(" \(typeCount[index])개")
+            typeName[index]?.append(" \(typeCount[index])\(Message.countResult.countUnit)")
         }
-        return typeName.compactMap({$0}).joined(separator: ", ")
+        return typeName.compactMap({$0}).joined(separator: "\(Message.countResult.comma) ")
     }
     
     static func showTypeCountOf(JSON stringArray: [String]) {
         let totalCount = stringArray.count
         let typeCount = addTypeName(in: stringArray)
-        print("총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다.")
+        print(Message.countResult.makeSentence(with: totalCount, and: typeCount))
+    }
+    
+    static func notifyIssue() {
+        print(Message.invalidJSON)
     }
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -8,47 +8,40 @@
 
 import Foundation
 
-struct OutputView {
-    private struct Message {
-        static let invalidForm = "지원하는 규격이 아닙니다."
-        
-        struct countResult {
-            static let typeString = "문자열"
-            static let typeDouble = "숫자"
-            static let typeBool = "부울"
-            static let noCount = 0
-            static let countUnit = "개"
-            static let comma = ","
-            static func makeSentence(with totalCount: Int, and typeCount: String) -> String {
-                return "총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다."
-            }
+struct Message {
+    static let invalidForm = "지원하는 규격이 아닙니다."
+    
+    struct countResult {
+        static let string = "문자열"
+        static let int = "숫자"
+        static let bool = "부울"
+        static let noCount = 0
+        static let countUnit = "개"
+        static let comma = ","
+        static func makeSentence(with totalCount: Int, and typeCount: String) -> String {
+            return "총 \(totalCount)개의 데이터 중에 \(typeCount)가 포함되어 있습니다."
         }
     }
-    
-    private static func countType(in stringArray: [String]) -> [Int] {
-        var typeCount = [Int]()
-        typeCount.append(StringInspector.countType(in: stringArray))
-        typeCount.append(DoubleInspector.countType(in: stringArray))
-        typeCount.append(BooleanInspector.countType(in: stringArray))
-        return typeCount
-    }
-    
-    private static func addTypeName(in stringArray: [String]) -> String {
-        var typeName: [String?] = [Message.countResult.typeString, Message.countResult.typeDouble, Message.countResult.typeBool]
-        let typeCount = countType(in: stringArray)
+}
+
+struct OutputView {
+    private static func addTypeName(to jsonArray: [Any?]) -> String {
+        var typeName: [String?] = [Message.countResult.string, Message.countResult.int, Message.countResult.bool]
+        let typeCount = TypeInspector.countType(of: jsonArray)
         for index in 0..<typeName.count {
-            if (typeCount[index] == Message.countResult.noCount) {
+            let key = typeName[index] ?? ""
+            guard let count = typeCount[key] else {
                 typeName[index] = nil
                 continue
             }
-            typeName[index]?.append(" \(typeCount[index])\(Message.countResult.countUnit)")
+            typeName[index]?.append(" \(count)\(Message.countResult.countUnit)")
         }
         return typeName.compactMap({$0}).joined(separator: "\(Message.countResult.comma) ")
     }
     
-    static func showTypeCountOf(JSON stringArray: [String]) {
-        let totalCount = stringArray.count
-        let typeCount = addTypeName(in: stringArray)
+    static func showTypeCountOf(JSON jsonArray: [Any?]) {
+        let totalCount = jsonArray.count
+        let typeCount = addTypeName(to: jsonArray)
         print(Message.countResult.makeSentence(with: totalCount, and: typeCount))
     }
     

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -1,0 +1,12 @@
+//
+//  OutputView.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 18/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct OutputView {
+}

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,4 +9,11 @@
 import Foundation
 
 struct OutputView {
+    static func showTypeCountOf(JSON stringArray: [String]) {
+        let totalCount = stringArray.count
+        let stringCout = StringInspector.countType(in: stringArray)
+        let doubleCount = DoubleInspector.countType(in: stringArray)
+        let boolCount = BooleanInspector.countType(in: stringArray)
+        print("총 \(totalCount)개의 데이터 중에 문자열 \(stringCout)개, 숫자 \(doubleCount)개, 부울 \(boolCount)개가 포함되어 있습니다.")
+    }
 }

--- a/JSONParser/JSONParser/TypeInspector.swift
+++ b/JSONParser/JSONParser/TypeInspector.swift
@@ -30,7 +30,7 @@ struct DoubleInspector: TypeInspector {
 }
 
 struct BooleanInspector: TypeInspector {
-    private static let boolExpression = Set(["True", "true", "False", "false"])
+    private static let boolExpression = Set(["true", "false"])
     private static func isBoolExpression(_ text: String) -> Bool? {
         return boolExpression.contains(text) ? true : nil
     }

--- a/JSONParser/JSONParser/TypeInspector.swift
+++ b/JSONParser/JSONParser/TypeInspector.swift
@@ -1,0 +1,40 @@
+//
+//  File.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 18/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+protocol TypeInspector {
+    static func countType(stringArray: [String]) -> Int
+}
+
+struct StringInspector: TypeInspector {
+    private static let doubleQuotation: Character = "\""
+    private static func hasDoubleQuotation(_ text: String) -> Bool {
+        return (text.count > 1 && text.first == doubleQuotation && text.last == doubleQuotation)
+    }
+    static func countType(stringArray: [String]) -> Int {
+        let typeArray = stringArray.map({ hasDoubleQuotation($0) ? $0.trimDoubleQuotation() : nil })
+        return typeArray.compactMap({ $0 }).count
+    }
+}
+
+struct DoubleInspector: TypeInspector {
+    static func countType(stringArray: [String]) -> Int {
+        return stringArray.compactMap({ Double($0) }).count
+    }
+}
+
+struct BooleanInspector: TypeInspector {
+    private static let boolExpression = Set(["A", "B", "C", "D"])
+    private static func isBoolExpression(_ text: String) -> Bool? {
+        return boolExpression.contains(text) ? true : nil
+    }
+    static func countType(stringArray: [String]) -> Int {
+        return stringArray.compactMap({ Bool($0) }).count
+    }
+}

--- a/JSONParser/JSONParser/TypeInspector.swift
+++ b/JSONParser/JSONParser/TypeInspector.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+public enum typeName: String {
+    case string = "문자열"
+    case int = "숫자"
+    case bool = "부울"
+    case none = ""
+}
+
 struct TypeInspector {
     static func countType(of jsonArray: [Any?]) -> [String: Int] {
         var typeCount: [String: Int] = [:]
@@ -16,13 +23,13 @@ struct TypeInspector {
         for value in jsonArray {
             switch value {
             case is String:
-                typeCount["문자열"] = (typeCount["문자열"] ?? defaultValue) + count
+                typeCount[typeName.string.rawValue] = (typeCount[typeName.string.rawValue] ?? defaultValue) + count
             case is Int:
-                typeCount["숫자"] = (typeCount["숫자"] ?? defaultValue) + count
+                typeCount[typeName.int.rawValue] = (typeCount[typeName.int.rawValue] ?? defaultValue) + count
             case is Bool:
-                typeCount["부울"] = (typeCount["부울"] ?? defaultValue) + count
+                typeCount[typeName.bool.rawValue] = (typeCount[typeName.bool.rawValue] ?? defaultValue) + count
             default:
-                typeCount["nil"] = (typeCount["nil"] ?? defaultValue) + count
+                continue
             }
         }
         return typeCount

--- a/JSONParser/JSONParser/TypeInspector.swift
+++ b/JSONParser/JSONParser/TypeInspector.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol TypeInspector {
-    static func countType(stringArray: [String]) -> Int
+    static func countType(in stringArray: [String]) -> Int
 }
 
 struct StringInspector: TypeInspector {
@@ -17,24 +17,24 @@ struct StringInspector: TypeInspector {
     private static func hasDoubleQuotation(_ text: String) -> Bool {
         return (text.count > 1 && text.first == doubleQuotation && text.last == doubleQuotation)
     }
-    static func countType(stringArray: [String]) -> Int {
+    static func countType(in stringArray: [String]) -> Int {
         let typeArray = stringArray.map({ hasDoubleQuotation($0) ? $0.trimDoubleQuotation() : nil })
         return typeArray.compactMap({ $0 }).count
     }
 }
 
 struct DoubleInspector: TypeInspector {
-    static func countType(stringArray: [String]) -> Int {
+    static func countType(in stringArray: [String]) -> Int {
         return stringArray.compactMap({ Double($0) }).count
     }
 }
 
 struct BooleanInspector: TypeInspector {
-    private static let boolExpression = Set(["A", "B", "C", "D"])
+    private static let boolExpression = Set(["True", "true", "False", "false"])
     private static func isBoolExpression(_ text: String) -> Bool? {
         return boolExpression.contains(text) ? true : nil
     }
-    static func countType(stringArray: [String]) -> Int {
+    static func countType(in stringArray: [String]) -> Int {
         return stringArray.compactMap({ Bool($0) }).count
     }
 }

--- a/JSONParser/JSONParser/TypeInspector.swift
+++ b/JSONParser/JSONParser/TypeInspector.swift
@@ -8,33 +8,24 @@
 
 import Foundation
 
-protocol TypeInspector {
-    static func countType(in stringArray: [String]) -> Int
+struct TypeInspector {
+    static func countType(of jsonArray: [Any?]) -> [String: Int] {
+        var typeCount: [String: Int] = [:]
+        let defaultValue = 0
+        let count = 1
+        for value in jsonArray {
+            switch value {
+            case is String:
+                typeCount["문자열"] = (typeCount["문자열"] ?? defaultValue) + count
+            case is Int:
+                typeCount["숫자"] = (typeCount["숫자"] ?? defaultValue) + count
+            case is Bool:
+                typeCount["부울"] = (typeCount["부울"] ?? defaultValue) + count
+            default:
+                typeCount["nil"] = (typeCount["nil"] ?? defaultValue) + count
+            }
+        }
+        return typeCount
+    }
 }
 
-struct StringInspector: TypeInspector {
-    private static let doubleQuotation: Character = "\""
-    private static func hasDoubleQuotation(_ text: String) -> Bool {
-        return (text.count > 1 && text.first == doubleQuotation && text.last == doubleQuotation)
-    }
-    static func countType(in stringArray: [String]) -> Int {
-        let typeArray = stringArray.map({ hasDoubleQuotation($0) ? $0.trimDoubleQuotation() : nil })
-        return typeArray.compactMap({ $0 }).count
-    }
-}
-
-struct DoubleInspector: TypeInspector {
-    static func countType(in stringArray: [String]) -> Int {
-        return stringArray.compactMap({ Double($0) }).count
-    }
-}
-
-struct BooleanInspector: TypeInspector {
-    private static let boolExpression = Set(["true", "false"])
-    private static func isBoolExpression(_ text: String) -> Bool? {
-        return boolExpression.contains(text) ? true : nil
-    }
-    static func countType(in stringArray: [String]) -> Int {
-        return stringArray.compactMap({ Bool($0) }).count
-    }
-}

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -11,7 +11,10 @@ import Foundation
 struct JSONParser {
     static func run() {
         let jsonString = InputView.readInput()
-        let stringArray = JSONGenerator.stringArray(jsonString)
+        guard let stringArray = JSONGenerator.extractStringArray(from: jsonString) else {
+            OutputView.notifyIssue()
+            return
+        }
         OutputView.showTypeCountOf(JSON: stringArray)
     }
 }

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -11,11 +11,11 @@ import Foundation
 struct JSONParser {
     static func run() {
         let jsonString = InputView.readInput()
-        guard let stringArray = JSONGenerator.extractStringArray(from: jsonString) else {
+        guard let jsonArray: [Any?] = JSONGenerator.makeJSONArray(from: jsonString) else {
             OutputView.notifyIssue()
             return
         }
-        OutputView.showTypeCountOf(JSON: stringArray)
+        OutputView.showTypeCountOf(JSON: jsonArray)
     }
 }
 

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -8,3 +8,12 @@
 
 import Foundation
 
+struct JSONParser {
+    static func run() {
+        let jsonString = InputView.readInput()
+        let stringArray = JSONGenerator.stringArray(jsonString)
+        let dataCount = stringArray.count
+    }
+}
+
+JSONParser.run()

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -12,7 +12,7 @@ struct JSONParser {
     static func run() {
         let jsonString = InputView.readInput()
         let stringArray = JSONGenerator.stringArray(jsonString)
-        let dataCount = stringArray.count
+        OutputView.showTypeCountOf(JSON: stringArray)
     }
 }
 

--- a/JSONParser/JSONParserUnitTest/Info.plist
+++ b/JSONParser/JSONParserUnitTest/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
@@ -33,6 +33,21 @@ class UnitTestExtensions: XCTestCase {
         XCTAssertTrue(jsonString.hasSideSquareBrackets())
     }
     
+    func testHasTwoDoubleQuotation() {
+        let stringSurroundedDoubleQuotation = "\"jamie\""
+        XCTAssertTrue(stringSurroundedDoubleQuotation.hasDoubleQuotation())
+    }
+    
+    func testHasOneDoubleQuotation() {
+        let stringSurroundedOneDoubleQuotation = "\"jamie"
+        XCTAssertFalse(stringSurroundedOneDoubleQuotation.hasDoubleQuotation())
+    }
+    
+    func testHasNoDoubleQuotation() {
+        let stringSurroundedOneDoubleQuotation = "jamie"
+        XCTAssertFalse(stringSurroundedOneDoubleQuotation.hasDoubleQuotation())
+    }
+    
     func testTrimSquareBrackets() {
         let trimmedSquareBrackets = " 10, \"jk\", 4, \"314\", 99, \"crong\", false "
         let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"

--- a/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
@@ -1,0 +1,16 @@
+//
+//  UnitTestExtensions.swift
+//  JSONParserUnitTest
+//
+//  Created by 윤지영 on 19/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import XCTest
+
+class UnitTestExtensions: XCTestCase {
+    override func setUp() {}
+    override func tearDown() {}
+
+    func testExample() {}
+}

--- a/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
@@ -9,8 +9,44 @@
 import XCTest
 
 class UnitTestExtensions: XCTestCase {
+    let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
+    let noWhiteSpace = "[10,\"jk\",4,\"314\",99,\"crong\",false]"
+    let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
+    let oneSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
+    let trimmedSquareBrackets = " 10, \"jk\", 4, \"314\", 99, \"crong\", false "
+    let stringSurroundedDoubleQuotation = "\"jamie\""
+    let trimmedDoubleQuotation = "jamie"
+    let splitArray = ["[ 10", " \"jk\"", " 4", " \"314\"", " 99", " \"crong\"", " false ]"]
+    
     override func setUp() {}
     override func tearDown() {}
 
-    func testExample() {}
+    func testRemoveWhiteSpaces() {
+        XCTAssertEqual(jsonString.removeWhiteSpaces(), noWhiteSpace)
+    }
+    
+    func testHasNoSideSquareBracket() {
+        XCTAssertFalse(noSideSquareBracket.hasSideSquareBrackets())
+    }
+    
+    func testHasOneSideSquartBracket() {
+        XCTAssertFalse(oneSideSquareBracket.hasSideSquareBrackets())
+    }
+    
+    func testHasSideSquareBrackets() {
+        XCTAssertTrue(jsonString.hasSideSquareBrackets())
+    }
+    
+    func testTrimSquareBrackets() {
+        XCTAssertEqual(jsonString.trimSquareBrackets(), trimmedSquareBrackets)
+    }
+    
+    func testTrimDoubleQuotation() {
+        XCTAssertEqual(stringSurroundedDoubleQuotation.trimDoubleQuotation(), trimmedDoubleQuotation)
+    }
+    
+    func testSplitByComma() {
+        XCTAssertEqual(jsonString.splitByComma(), splitArray)
+    }
+    
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestExtensions.swift
@@ -9,43 +9,45 @@
 import XCTest
 
 class UnitTestExtensions: XCTestCase {
-    let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
-    let noWhiteSpace = "[10,\"jk\",4,\"314\",99,\"crong\",false]"
-    let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
-    let oneSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
-    let trimmedSquareBrackets = " 10, \"jk\", 4, \"314\", 99, \"crong\", false "
-    let stringSurroundedDoubleQuotation = "\"jamie\""
-    let trimmedDoubleQuotation = "jamie"
-    let splitArray = ["[ 10", " \"jk\"", " 4", " \"314\"", " 99", " \"crong\"", " false ]"]
-    
     override func setUp() {}
     override func tearDown() {}
 
     func testRemoveWhiteSpaces() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
+        let noWhiteSpace = "[10,\"jk\",4,\"314\",99,\"crong\",false]"
         XCTAssertEqual(jsonString.removeWhiteSpaces(), noWhiteSpace)
     }
     
     func testHasNoSideSquareBracket() {
+        let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
         XCTAssertFalse(noSideSquareBracket.hasSideSquareBrackets())
     }
     
     func testHasOneSideSquartBracket() {
+         let oneSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
         XCTAssertFalse(oneSideSquareBracket.hasSideSquareBrackets())
     }
     
     func testHasSideSquareBrackets() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
         XCTAssertTrue(jsonString.hasSideSquareBrackets())
     }
     
     func testTrimSquareBrackets() {
+        let trimmedSquareBrackets = " 10, \"jk\", 4, \"314\", 99, \"crong\", false "
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
         XCTAssertEqual(jsonString.trimSquareBrackets(), trimmedSquareBrackets)
     }
     
     func testTrimDoubleQuotation() {
+        let trimmedDoubleQuotation = "jamie"
+        let stringSurroundedDoubleQuotation = "\"jamie\""
         XCTAssertEqual(stringSurroundedDoubleQuotation.trimDoubleQuotation(), trimmedDoubleQuotation)
     }
     
     func testSplitByComma() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
+        let splitArray = ["[ 10", " \"jk\"", " 4", " \"314\"", " 99", " \"crong\"", " false ]"]
         XCTAssertEqual(jsonString.splitByComma(), splitArray)
     }
     

--- a/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
@@ -9,8 +9,28 @@
 import XCTest
 
 class UnitTestJSONGenerator: XCTestCase {
+    let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
+    let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
+    let oneLeftSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
+    let oneRightSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\"]"
+    let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false"]
+    
     override func setUp() {}
     override func tearDown() {}
 
-    func testExample() {}
+    func testExtractStringArray_whenValid() {
+        XCTAssertEqual(JSONGenerator.extractStringArray(from: jsonString), jsonStringArray)
+    }
+    
+    func testExtractNil_whenNoSideSquareBracke() {
+        XCTAssertNil(JSONGenerator.extractStringArray(from: noSideSquareBracket))
+    }
+    
+    func testExtractNil_whenOneLeftSideSquareBracke() {
+        XCTAssertNil(JSONGenerator.extractStringArray(from: oneLeftSideSquareBracket))
+    }
+    
+    func testExtractNil_whenOneRightSideSquareBracke() {
+        XCTAssertNil(JSONGenerator.extractStringArray(from: oneRightSideSquareBracket))
+    }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
@@ -1,0 +1,16 @@
+//
+//  JSONParserUnitTest.swift
+//  JSONParserUnitTest
+//
+//  Created by 윤지영 on 19/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import XCTest
+
+class UnitTestJSONGenerator: XCTestCase {
+    override func setUp() {}
+    override func tearDown() {}
+
+    func testExample() {}
+}

--- a/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
@@ -9,28 +9,27 @@
 import XCTest
 
 class UnitTestJSONGenerator: XCTestCase {
-    let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
-    let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
-    let oneLeftSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
-    let oneRightSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\"]"
-    let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false"]
-    
     override func setUp() {}
     override func tearDown() {}
 
     func testExtractStringArray_whenValid() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
+        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false"]
         XCTAssertEqual(JSONGenerator.extractStringArray(from: jsonString), jsonStringArray)
     }
     
     func testExtractNil_whenNoSideSquareBracke() {
+        let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
         XCTAssertNil(JSONGenerator.extractStringArray(from: noSideSquareBracket))
     }
     
     func testExtractNil_whenOneLeftSideSquareBracke() {
+        let oneLeftSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
         XCTAssertNil(JSONGenerator.extractStringArray(from: oneLeftSideSquareBracket))
     }
     
     func testExtractNil_whenOneRightSideSquareBracke() {
+        let oneRightSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\"]"
         XCTAssertNil(JSONGenerator.extractStringArray(from: oneRightSideSquareBracket))
     }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestJSONGenerator.swift
@@ -11,25 +11,33 @@ import XCTest
 class UnitTestJSONGenerator: XCTestCase {
     override func setUp() {}
     override func tearDown() {}
+    
+    func testMakeJSONArrayNil_whenStringHasNoTwoSquareBrackets() {
+        let jsonStringWithOneSquareBracket = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false"
+        XCTAssertNil(JSONGenerator.makeJSONArray(from: jsonStringWithOneSquareBracket))
+    }
 
-    func testExtractStringArray_whenValid() {
-        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, \"crong\", false ]"
-        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false"]
-        XCTAssertEqual(JSONGenerator.extractStringArray(from: jsonString), jsonStringArray)
+    func testJSONArrayStoresRightType_Int() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, false, a ]"
+        let jsonArray = JSONGenerator.makeJSONArray(from: jsonString)
+        XCTAssertTrue(jsonArray?[0] is Int)
     }
     
-    func testExtractNil_whenNoSideSquareBracke() {
-        let noSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\""
-        XCTAssertNil(JSONGenerator.extractStringArray(from: noSideSquareBracket))
+    func testJSONArrayStoresRightType_String() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, false, a ]"
+        let jsonArray = JSONGenerator.makeJSONArray(from: jsonString)
+        XCTAssertTrue(jsonArray?[1] is String)
     }
     
-    func testExtractNil_whenOneLeftSideSquareBracke() {
-        let oneLeftSideSquareBracket = "[10, \"jk\", 4, \"314\", 99, \"crong\""
-        XCTAssertNil(JSONGenerator.extractStringArray(from: oneLeftSideSquareBracket))
+    func testJSONArrayStoresRightType_Bool() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, false, a ]"
+        let jsonArray = JSONGenerator.makeJSONArray(from: jsonString)
+        XCTAssertTrue(jsonArray?[5] is Bool)
     }
     
-    func testExtractNil_whenOneRightSideSquareBracke() {
-        let oneRightSideSquareBracket = "10, \"jk\", 4, \"314\", 99, \"crong\"]"
-        XCTAssertNil(JSONGenerator.extractStringArray(from: oneRightSideSquareBracket))
+    func testJSONArrayStoresRightType_Nil() {
+        let jsonString = "[ 10, \"jk\", 4, \"314\", 99, false, a ]"
+        let jsonArray = JSONGenerator.makeJSONArray(from: jsonString)
+        XCTAssertNil(jsonArray?[6])
     }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
@@ -9,30 +9,31 @@
 import XCTest
 
 class UnitTestTypeInspector: XCTestCase {
-    let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
-    let jsonIncludingDouble = ["\"314\"", "99.12", "\"crong\"", "false"]
-    let jsonIncludeInvalidBool = ["flase", "ttrue", "Truee", "False"]
-    
     override func setUp() {}
     override func tearDown() {}
     
     func testCountStringType() {
+        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
         XCTAssertEqual(StringInspector.countType(in: jsonStringArray), 3)
     }
     
     func testCountNumber() {
+        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
         XCTAssertEqual(DoubleInspector.countType(in: jsonStringArray), 3)
     }
     
     func testCountNumberIncludingDouble() {
+        let jsonIncludingDouble = ["\"314\"", "99.12", "\"crong\"", "false"]
         XCTAssertEqual(DoubleInspector.countType(in: jsonIncludingDouble), 1)
     }
     
     func testCountBool() {
+        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
         XCTAssertEqual(BooleanInspector.countType(in: jsonStringArray), 1)
     }
     
     func testCountOnlyValidBool() {
-        XCTAssertEqual(BooleanInspector.countType(in: jsonStringArray), 1)
+        let jsonIncludeInvalidBool = ["flase", "ttrue", "Truee", "false"]
+        XCTAssertEqual(BooleanInspector.countType(in: jsonIncludeInvalidBool), 1)
     }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
@@ -9,8 +9,30 @@
 import XCTest
 
 class UnitTestTypeInspector: XCTestCase {
+    let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
+    let jsonIncludingDouble = ["\"314\"", "99.12", "\"crong\"", "false"]
+    let jsonIncludeInvalidBool = ["flase", "ttrue", "Truee", "False"]
+    
     override func setUp() {}
     override func tearDown() {}
-
-    func testExample() {}
+    
+    func testCountStringType() {
+        XCTAssertEqual(StringInspector.countType(in: jsonStringArray), 3)
+    }
+    
+    func testCountNumber() {
+        XCTAssertEqual(DoubleInspector.countType(in: jsonStringArray), 3)
+    }
+    
+    func testCountNumberIncludingDouble() {
+        XCTAssertEqual(DoubleInspector.countType(in: jsonIncludingDouble), 1)
+    }
+    
+    func testCountBool() {
+        XCTAssertEqual(BooleanInspector.countType(in: jsonStringArray), 1)
+    }
+    
+    func testCountOnlyValidBool() {
+        XCTAssertEqual(BooleanInspector.countType(in: jsonStringArray), 1)
+    }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
@@ -9,31 +9,24 @@
 import XCTest
 
 class UnitTestTypeInspector: XCTestCase {
-    override func setUp() {}
+    var jsonArray: [Any?] = []
+    var typeCount: [String: Int] = [:]
+    
+    override func setUp() {
+        jsonArray = [10, "jk", 4, "314", 99, "crong", false, nil]
+        typeCount = TypeInspector.countType(of: jsonArray)
+    }
     override func tearDown() {}
     
     func testCountStringType() {
-        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
-        XCTAssertEqual(StringInspector.countType(in: jsonStringArray), 3)
+        XCTAssertEqual(typeCount[typeName.string.rawValue], 3)
     }
-    
+
     func testCountNumber() {
-        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
-        XCTAssertEqual(DoubleInspector.countType(in: jsonStringArray), 3)
-    }
-    
-    func testCountNumberIncludingDouble() {
-        let jsonIncludingDouble = ["\"314\"", "99.12", "\"crong\"", "false"]
-        XCTAssertEqual(DoubleInspector.countType(in: jsonIncludingDouble), 1)
+        XCTAssertEqual(typeCount[typeName.int.rawValue], 3)
     }
     
     func testCountBool() {
-        let jsonStringArray = ["10", "\"jk\"", "4", "\"314\"", "99", "\"crong\"", "false", "a"]
-        XCTAssertEqual(BooleanInspector.countType(in: jsonStringArray), 1)
-    }
-    
-    func testCountOnlyValidBool() {
-        let jsonIncludeInvalidBool = ["flase", "ttrue", "Truee", "false"]
-        XCTAssertEqual(BooleanInspector.countType(in: jsonIncludeInvalidBool), 1)
+        XCTAssertEqual(typeCount[typeName.bool.rawValue], 1)
     }
 }

--- a/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestTypeInspector.swift
@@ -1,0 +1,16 @@
+//
+//  UnitTestTypeInspector.swift
+//  JSONParserUnitTest
+//
+//  Created by 윤지영 on 19/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import XCTest
+
+class UnitTestTypeInspector: XCTestCase {
+    override func setUp() {}
+    override func tearDown() {}
+
+    func testExample() {}
+}


### PR DESCRIPTION
- 아래의 흐름으로 JSONParser를 구현했습니다.
  1. `InputView` 로 입력값을 받아온다.
  2.  입력받은 문자열을 `JSONGenerator` 을 통해 문자열 배열로 분리한다. 문자열을 다루는 기능을 `Extensions` 에 추가로 구현한다. 지원하지 않는 형식일 경우 문자열 배열 대신 `nil` 을 리턴하고, 안내메세지와 함께 프로그램을 종료한다.
  3. 리턴받은 문자열 배열에서 `TypeInspector` 로 특정 타입을 카운트한 결과를 `OutputView` 에서 출력한다.
- 설계한 기능들에 대해 각각 단위테스트를 시행했습니다. 