### PR TITLE
JSON문자열 분석기 3단계 - 규칙 검사하기

### DIFF
--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A3E93B922186AAAB00828D73 /* GrammarChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B902186AAAB00828D73 /* GrammarChecker.swift */; };
 		A3E93B942186D06000828D73 /* JSONRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B932186D06000828D73 /* JSONRegex.swift */; };
 		A3E93B952186D06000828D73 /* JSONRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B932186D06000828D73 /* JSONRegex.swift */; };
+		A3E93B972186D4D000828D73 /* UnitTestGrammarChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B962186D4D000828D73 /* UnitTestGrammarChecker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -61,6 +62,7 @@
 		A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestExtensions.swift; sourceTree = "<group>"; };
 		A3E93B902186AAAB00828D73 /* GrammarChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarChecker.swift; sourceTree = "<group>"; };
 		A3E93B932186D06000828D73 /* JSONRegex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRegex.swift; sourceTree = "<group>"; };
+		A3E93B962186D4D000828D73 /* UnitTestGrammarChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestGrammarChecker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +126,7 @@
 				A3D86FA02179AB2A0044CFD9 /* Info.plist */,
 				A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */,
 				A3C3502821841493001B80BC /* UnitTestJSONDataForm.swift */,
+				A3E93B962186D4D000828D73 /* UnitTestGrammarChecker.swift */,
 			);
 			path = JSONParserUnitTest;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 				A3D86FA42179AB610044CFD9 /* Extensions.swift in Sources */,
 				A34DBE18217EC9BE00D29AD0 /* JSONValue.swift in Sources */,
 				A3E93B922186AAAB00828D73 /* GrammarChecker.swift in Sources */,
+				A3E93B972186D4D000828D73 /* UnitTestGrammarChecker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		A3D86FA42179AB610044CFD9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F92217872D20044CFD9 /* Extensions.swift */; };
 		A3D86FA52179AB680044CFD9 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F942178749B0044CFD9 /* JSONParser.swift */; };
 		A3D86FA82179ABB40044CFD9 /* UnitTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */; };
+		A3E93B912186AAAB00828D73 /* GrammarChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B902186AAAB00828D73 /* GrammarChecker.swift */; };
+		A3E93B922186AAAB00828D73 /* GrammarChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B902186AAAB00828D73 /* GrammarChecker.swift */; };
+		A3E93B942186D06000828D73 /* JSONRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B932186D06000828D73 /* JSONRegex.swift */; };
+		A3E93B952186D06000828D73 /* JSONRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E93B932186D06000828D73 /* JSONRegex.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -55,6 +59,8 @@
 		A3D86F9E2179AB2A0044CFD9 /* UnitTestJSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestJSONParser.swift; sourceTree = "<group>"; };
 		A3D86FA02179AB2A0044CFD9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A3D86FA72179ABB40044CFD9 /* UnitTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestExtensions.swift; sourceTree = "<group>"; };
+		A3E93B902186AAAB00828D73 /* GrammarChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarChecker.swift; sourceTree = "<group>"; };
+		A3E93B932186D06000828D73 /* JSONRegex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRegex.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +111,8 @@
 				A39A96BB2181ED0800FA6EEF /* JSONObject.swift */,
 				A39A96BE2181ED1400FA6EEF /* JSONArray.swift */,
 				A3D86F92217872D20044CFD9 /* Extensions.swift */,
+				A3E93B902186AAAB00828D73 /* GrammarChecker.swift */,
+				A3E93B932186D06000828D73 /* JSONRegex.swift */,
 			);
 			path = JSONParser;
 			sourceTree = "<group>";
@@ -217,8 +225,10 @@
 				A39A96BF2181ED1400FA6EEF /* JSONArray.swift in Sources */,
 				A39A96BC2181ED0800FA6EEF /* JSONObject.swift in Sources */,
 				A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */,
+				A3E93B942186D06000828D73 /* JSONRegex.swift in Sources */,
 				A34DBE17217EC9BE00D29AD0 /* JSONValue.swift in Sources */,
 				A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */,
+				A3E93B912186AAAB00828D73 /* GrammarChecker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,8 +243,10 @@
 				A3D86F9F2179AB2A0044CFD9 /* UnitTestJSONParser.swift in Sources */,
 				A39A96C02181ED1400FA6EEF /* JSONArray.swift in Sources */,
 				A39A96BD2181ED0800FA6EEF /* JSONObject.swift in Sources */,
+				A3E93B952186D06000828D73 /* JSONRegex.swift in Sources */,
 				A3D86FA42179AB610044CFD9 /* Extensions.swift in Sources */,
 				A34DBE18217EC9BE00D29AD0 /* JSONValue.swift in Sources */,
+				A3E93B922186AAAB00828D73 /* GrammarChecker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -1,0 +1,21 @@
+//
+//  GrammarChecker.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 29/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct GrammarChecker {
+
+    static func isValid(jsonString: String, for pattern: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return false }
+        let fullRange = NSRange(jsonString.startIndex..., in: jsonString)
+        let matchRange = regex.rangeOfFirstMatch(in: jsonString, options: [], range: fullRange)
+        guard fullRange == matchRange else { return false }
+        return true
+    }
+
+}

--- a/JSONParser/JSONParser/GrammarChecker.swift
+++ b/JSONParser/JSONParser/GrammarChecker.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct GrammarChecker {
 
-    static func isValid(jsonString: String, for pattern: String) -> Bool {
+    static func isValid(_ jsonString: String, for pattern: String) -> Bool {
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return false }
         let fullRange = NSRange(jsonString.startIndex..., in: jsonString)
         let matchRange = regex.rangeOfFirstMatch(in: jsonString, options: [], range: fullRange)

--- a/JSONParser/JSONParser/JSONParser.swift
+++ b/JSONParser/JSONParser/JSONParser.swift
@@ -66,11 +66,14 @@ struct JSONParser {
     }
 
     static func parse(_ jsonString: String) -> JSONDataForm? {
+        let jsonString = jsonString.trimWhiteSpaces()
         if jsonString.hasSideSquareBrackets() {
+            guard GrammarChecker.isValid(jsonString, for: JSONRegex.jsonArray) else { return nil }
             guard let jsonArray = makeJSONArray(from: jsonString) else { return nil }
             return JSONArray.init(jsonArray)
         }
         if jsonString.hasSideCurlyBrackets() {
+            guard GrammarChecker.isValid(jsonString, for: JSONRegex.jsonObject) else { return nil }
             guard let jsonObject = makeJSONObject(from: jsonString) else { return nil }
             return JSONObject.init(jsonObject)
         }

--- a/JSONParser/JSONParser/JSONParser.swift
+++ b/JSONParser/JSONParser/JSONParser.swift
@@ -43,8 +43,7 @@ struct JSONParser {
 
     private static func makeJSONObject(from jsonString: String) -> [String: JSONValue]? {
         var jsonObject = [String: JSONValue]()
-        let regexKeyValueInJSONObject = "\"[\\w]+\"\\s*:\\s*[\"\\w\\s]+"
-        let keyValues = captureGroup(in: jsonString, by: regexKeyValueInJSONObject)
+        let keyValues = captureGroup(in: jsonString, by: JSONRegex.keyValue)
         guard keyValues.count == jsonString.splitByComma().count else { return nil }
         for keyValue in keyValues {
             let keyValueSplit = extractKeyValue(from: keyValue)
@@ -56,8 +55,7 @@ struct JSONParser {
 
     private static func makeJSONArray(from jsonString: String) -> [JSONValue]? {
         var jsonArray = [JSONValue]()
-        let regexValuesInJSONArray = "(\\{(?:(?:\\s*\"[\\w]+\"\\s*:\\s*[\"\\w\\s]+\\s*),*)*\\}|\"[\\w]+\"|[0-9]+|false|true)"
-        let jsonValues = captureGroup(in: jsonString, by: regexValuesInJSONArray)
+        let jsonValues = captureGroup(in: jsonString, by: JSONRegex.valuesIncludingObject)
         for jsonValue in jsonValues {
             guard let jsonValueConverted = typeCast(from: jsonValue) else { return nil }
             jsonArray.append(jsonValueConverted)

--- a/JSONParser/JSONParser/JSONRegex.swift
+++ b/JSONParser/JSONParser/JSONRegex.swift
@@ -1,0 +1,30 @@
+//
+//  JSONRegex.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 29/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct JSONRegex {
+    private static let space = "\\s"
+    private static let colon = ":"
+    private static let leftCurlyBracket = "\\{"
+    private static let rightCurlyBracket = "\\}"
+    private static let leftSquareBracket = "\\["
+    private static let rightSquareBracket = "\\]"
+
+    private static let string = "\"[\\w_\(space)]+\""
+    private static let int = "[0-9]+"
+    private static let bool = "(?:true|false)"
+
+    private static let values = "\(string)|\(int)|\(bool)"
+    private static let keyValue = "\(string)\(space)*\(colon)\(space)*(?:\(values))"
+    private static let object = "\(leftCurlyBracket)\(space)*\(keyValue)\(space)*(?:,\(space)*\(keyValue)\(space)*)*\(rightCurlyBracket)"
+    static let jsonObject = "^\(object)$"
+
+    private static let valuesIncludingObject = "\(values)|\(object)"
+    static let jsonArray = "^\(leftSquareBracket)\(space)*(?:\(valuesIncludingObject))\(space)*(?:,\(space)*(?:\(valuesIncludingObject))\(space)*)*\(rightSquareBracket)$"
+}

--- a/JSONParser/JSONParser/JSONRegex.swift
+++ b/JSONParser/JSONParser/JSONRegex.swift
@@ -21,10 +21,10 @@ struct JSONRegex {
     private static let bool = "(?:true|false)"
 
     private static let values = "\(string)|\(int)|\(bool)"
-    private static let keyValue = "\(string)\(space)*\(colon)\(space)*(?:\(values))"
+    static let keyValue = "\(string)\(space)*\(colon)\(space)*(?:\(values))"
     private static let object = "\(leftCurlyBracket)\(space)*\(keyValue)\(space)*(?:,\(space)*\(keyValue)\(space)*)*\(rightCurlyBracket)"
     static let jsonObject = "^\(object)$"
 
-    private static let valuesIncludingObject = "\(values)|\(object)"
+    static let valuesIncludingObject = "\(values)|\(object)"
     static let jsonArray = "^\(leftSquareBracket)\(space)*(?:\(valuesIncludingObject))\(space)*(?:,\(space)*(?:\(valuesIncludingObject))\(space)*)*\(rightSquareBracket)$"
 }

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct OutputView {
     private struct Message {
-        static let invalidForm = "지원하는 규격이 아닙니다."
+        static let invalidForm = "지원하지 않는 형식을 포함하고 있습니다."
 
         struct countResult {
             static let noCount = 0

--- a/JSONParser/JSONParserUnitTest/UnitTestGrammarChecker.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestGrammarChecker.swift
@@ -1,0 +1,63 @@
+//
+//  UnitTestGrammarChecker.swift
+//  JSONParserUnitTest
+//
+//  Created by 윤지영 on 29/10/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import XCTest
+
+class UnitTestGrammarChecker: XCTestCase {
+
+    func testIsValid_whenObjectHasRightGrammar() {
+        let jsonObject = "{ \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }"
+        XCTAssertTrue(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsNotValid_whenObjectHasNoColon() {
+        let jsonObject = "{ \"name\" \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }"
+        XCTAssertFalse(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsNotValid_whenObjectHasNoComma() {
+        let jsonObject = "{ \"name\" : \"KIM JUNG\" \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }"
+        XCTAssertFalse(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsNotValid_whenObjectHasNothing() {
+        let jsonObject = "{  }"
+        XCTAssertFalse(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsNotValid_whenObjectKeyHasNoQuotation() {
+        let jsonObject = "{ \"name\" : \"KIM JUNG\", alias : \"JK\", \"level\" : 5, \"married\" : true }"
+        XCTAssertFalse(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsNotValid_whenObjectHasArray() {
+        let jsonObject = "{ \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true, \"array\" : [ \"nested\" ] }"
+        XCTAssertFalse(GrammarChecker.isValid(jsonObject, for: JSONRegex.jsonObject))
+    }
+
+    func testIsValid_whenArrayHasRightGrammar() {
+        let jsonArray = "[ { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }, { \"name\" : \"YOON JISU\", \"alias\" : \"crong\", \"level\" : 4, \"married\" : true } ]"
+        XCTAssertTrue(GrammarChecker.isValid(jsonArray, for: JSONRegex.jsonArray))
+    }
+
+    func testIsNotValid_whenArrayHasNotCompleteSquareBracket() {
+        let jsonArray = "[ { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }, { \"name\" : \"YOON JISU\", \"alias\" : \"crong\", \"level\" : 4, \"married\" : true } "
+        XCTAssertFalse(GrammarChecker.isValid(jsonArray, for: JSONRegex.jsonArray))
+    }
+
+    func testIsNotValid_whenArrayHasNotCompleteCurlyBracket() {
+        let jsonArray = "[ { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true , { \"name\" : \"YOON JISU\", \"alias\" : \"crong\", \"level\" : 4, \"married\" : true } ]"
+        XCTAssertFalse(GrammarChecker.isValid(jsonArray, for: JSONRegex.jsonArray))
+    }
+
+    func testIsNotValid_whenArrayHasNestedArray() {
+        let jsonArray = "[ { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, \"married\" : true }, { \"name\" : \"YOON JISU\", \"alias\" : \"crong\", \"level\" : 4, \"married\" : true }, [ \"nested\" ] ]"
+        XCTAssertFalse(GrammarChecker.isValid(jsonArray, for: JSONRegex.jsonArray))
+    }
+
+}

--- a/JSONParser/JSONParserUnitTest/UnitTestJSONParser.swift
+++ b/JSONParser/JSONParserUnitTest/UnitTestJSONParser.swift
@@ -35,4 +35,9 @@ class UnitTestJSONParser: XCTestCase {
         XCTAssertNil(JSONParser.parse(jsonString))
     }
 
+    func testParseNil_whenNoOneCurlyBracketInArray() {
+        let jsonString = "[ { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, married : true }, { \"name\" : \"KIM JUNG\", \"alias\" : \"JK\", \"level\" : 5, married : true ]"
+        XCTAssertNil(JSONParser.parse(jsonString))
+    }
+
 }


### PR DESCRIPTION
- `JSONRegex` 구조체를 생성하여 사용하는 정규표현식을 상수로 정리했습니다. 
- `GrammarChecker` 구조체를 생성하여 `isValid()` 메소드를 통해 올바른 JSON 문법인지 확인하는 절차를 추가했습니다. 해당 절차는 `JSONParser` 의 `parse()` 메소드 내부에서 수행하도록 했습니다.
- 수정 및 생성한 코드에 대해 단위테스트를 추가했습니다. 