### PR TITLE
JSON 문자열 분석기 6단계

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# json file
+*.json

--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		A34DBE18217EC9BE00D29AD0 /* JSONData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34DBE16217EC9BE00D29AD0 /* JSONData.swift */; };
 		A39A96C22181EE8200FA6EEF /* JSONDataForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A96C12181EE8200FA6EEF /* JSONDataForm.swift */; };
 		A39A96C32181EE8200FA6EEF /* JSONDataForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A96C12181EE8200FA6EEF /* JSONDataForm.swift */; };
+		A39DE60F2199176F00681D8C /* FileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE60E2199176F00681D8C /* FileReader.swift */; };
+		A39DE6112199550B00681D8C /* CommandLineReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE6102199550B00681D8C /* CommandLineReader.swift */; };
+		A39DE613219963E100681D8C /* JSONParserExcutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE612219963E100681D8C /* JSONParserExcutable.swift */; };
 		A3C3502921841493001B80BC /* UnitTestJSONDataForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C3502821841493001B80BC /* UnitTestJSONDataForm.swift */; };
 		A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F8E21786A2C0044CFD9 /* InputView.swift */; };
 		A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9021786A3D0044CFD9 /* OutputView.swift */; };
@@ -45,6 +48,9 @@
 		83AE2E0F1F8CAC2800F38CC9 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		A34DBE16217EC9BE00D29AD0 /* JSONData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONData.swift; sourceTree = "<group>"; };
 		A39A96C12181EE8200FA6EEF /* JSONDataForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataForm.swift; sourceTree = "<group>"; };
+		A39DE60E2199176F00681D8C /* FileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReader.swift; sourceTree = "<group>"; };
+		A39DE6102199550B00681D8C /* CommandLineReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineReader.swift; sourceTree = "<group>"; };
+		A39DE612219963E100681D8C /* JSONParserExcutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParserExcutable.swift; sourceTree = "<group>"; };
 		A3C3502821841493001B80BC /* UnitTestJSONDataForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestJSONDataForm.swift; sourceTree = "<group>"; };
 		A3D86F8E21786A2C0044CFD9 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
 		A3D86F9021786A3D0044CFD9 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
@@ -99,7 +105,10 @@
 			isa = PBXGroup;
 			children = (
 				83AE2E0F1F8CAC2800F38CC9 /* main.swift */,
+				A39DE612219963E100681D8C /* JSONParserExcutable.swift */,
 				A3D86F8E21786A2C0044CFD9 /* InputView.swift */,
+				A39DE6102199550B00681D8C /* CommandLineReader.swift */,
+				A39DE60E2199176F00681D8C /* FileReader.swift */,
 				A3D86F9021786A3D0044CFD9 /* OutputView.swift */,
 				A3D86F942178749B0044CFD9 /* JSONParser.swift */,
 				A34DBE16217EC9BE00D29AD0 /* JSONData.swift */,
@@ -214,11 +223,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				83AE2E101F8CAC2800F38CC9 /* main.swift in Sources */,
+				A39DE6112199550B00681D8C /* CommandLineReader.swift in Sources */,
 				A39A96C22181EE8200FA6EEF /* JSONDataForm.swift in Sources */,
 				A3D86F952178749B0044CFD9 /* JSONParser.swift in Sources */,
+				A39DE613219963E100681D8C /* JSONParserExcutable.swift in Sources */,
 				A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */,
 				A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */,
 				A3E93B942186D06000828D73 /* JSONRegex.swift in Sources */,
+				A39DE60F2199176F00681D8C /* FileReader.swift in Sources */,
 				A34DBE17217EC9BE00D29AD0 /* JSONData.swift in Sources */,
 				A3D86F93217872D20044CFD9 /* Extensions.swift in Sources */,
 				A3E93B912186AAAB00828D73 /* GrammarChecker.swift in Sources */,

--- a/JSONParser/JSONParser.xcodeproj/project.pbxproj
+++ b/JSONParser/JSONParser.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		A39A96C32181EE8200FA6EEF /* JSONDataForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A96C12181EE8200FA6EEF /* JSONDataForm.swift */; };
 		A39DE60F2199176F00681D8C /* FileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE60E2199176F00681D8C /* FileReader.swift */; };
 		A39DE6112199550B00681D8C /* CommandLineReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE6102199550B00681D8C /* CommandLineReader.swift */; };
-		A39DE613219963E100681D8C /* JSONParserExcutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE612219963E100681D8C /* JSONParserExcutable.swift */; };
+		A39DE613219963E100681D8C /* JSONParserExecutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39DE612219963E100681D8C /* JSONParserExecutable.swift */; };
 		A3C3502921841493001B80BC /* UnitTestJSONDataForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C3502821841493001B80BC /* UnitTestJSONDataForm.swift */; };
 		A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F8E21786A2C0044CFD9 /* InputView.swift */; };
 		A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D86F9021786A3D0044CFD9 /* OutputView.swift */; };
@@ -50,7 +50,7 @@
 		A39A96C12181EE8200FA6EEF /* JSONDataForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataForm.swift; sourceTree = "<group>"; };
 		A39DE60E2199176F00681D8C /* FileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReader.swift; sourceTree = "<group>"; };
 		A39DE6102199550B00681D8C /* CommandLineReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineReader.swift; sourceTree = "<group>"; };
-		A39DE612219963E100681D8C /* JSONParserExcutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParserExcutable.swift; sourceTree = "<group>"; };
+		A39DE612219963E100681D8C /* JSONParserExecutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParserExecutable.swift; sourceTree = "<group>"; };
 		A3C3502821841493001B80BC /* UnitTestJSONDataForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestJSONDataForm.swift; sourceTree = "<group>"; };
 		A3D86F8E21786A2C0044CFD9 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
 		A3D86F9021786A3D0044CFD9 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
@@ -105,7 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				83AE2E0F1F8CAC2800F38CC9 /* main.swift */,
-				A39DE612219963E100681D8C /* JSONParserExcutable.swift */,
+				A39DE612219963E100681D8C /* JSONParserExecutable.swift */,
 				A3D86F8E21786A2C0044CFD9 /* InputView.swift */,
 				A39DE6102199550B00681D8C /* CommandLineReader.swift */,
 				A39DE60E2199176F00681D8C /* FileReader.swift */,
@@ -226,7 +226,7 @@
 				A39DE6112199550B00681D8C /* CommandLineReader.swift in Sources */,
 				A39A96C22181EE8200FA6EEF /* JSONDataForm.swift in Sources */,
 				A3D86F952178749B0044CFD9 /* JSONParser.swift in Sources */,
-				A39DE613219963E100681D8C /* JSONParserExcutable.swift in Sources */,
+				A39DE613219963E100681D8C /* JSONParserExecutable.swift in Sources */,
 				A3D86F8F21786A2C0044CFD9 /* InputView.swift in Sources */,
 				A3D86F9121786A3D0044CFD9 /* OutputView.swift in Sources */,
 				A3E93B942186D06000828D73 /* JSONRegex.swift in Sources */,

--- a/JSONParser/JSONParser/CommandLineReader.swift
+++ b/JSONParser/JSONParser/CommandLineReader.swift
@@ -1,0 +1,27 @@
+//
+//  CommandLineReader.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 12/11/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct CommandLineReader {
+    enum Arguments: Int {
+        case projectDirectory = 0, inputFile, outputFile
+    }
+
+    static func readArgument(atIndex index: Arguments) -> String? {
+        let index = index.rawValue
+        let args = CommandLine.arguments
+        guard index < args.count else { return nil }
+        return args[index]
+    }
+    
+    static func hasArgument(atIndex index: Arguments) -> Bool {
+        guard readArgument(atIndex: index) != nil else { return false }
+        return true
+    }
+}

--- a/JSONParser/JSONParser/Extensions.swift
+++ b/JSONParser/JSONParser/Extensions.swift
@@ -24,6 +24,10 @@ extension String {
     func trimWhiteSpaces() -> String {
         return self.trimmingCharacters(in: CharacterSet(charactersIn: " "))
     }
+    
+    func trimNewLine() -> String {
+        return self.trimmingCharacters(in: CharacterSet(charactersIn: "\n"))
+    }
 
     func trimSquareBrackets() -> String {
         return self.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))

--- a/JSONParser/JSONParser/FileReader.swift
+++ b/JSONParser/JSONParser/FileReader.swift
@@ -1,0 +1,29 @@
+//
+//  FileReader.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 12/11/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+struct FileReader {
+
+    static func getDocumentURL(with file: String? = nil) -> URL? {
+        let documentURL = try? FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false)
+        guard let file = file else { return documentURL }
+        let documentURLIncludingFile = documentURL?.appendingPathComponent(file)
+        return documentURLIncludingFile
+    }
+
+    static func readContents(from file: String) -> String? {
+        guard let fileURL = getDocumentURL(with: file) else { return nil }
+        guard let contents = try? String(contentsOf: fileURL) else { return nil }
+        return contents
+    }
+}

--- a/JSONParser/JSONParser/InputView.swift
+++ b/JSONParser/JSONParser/InputView.swift
@@ -10,24 +10,7 @@ import Foundation
 
 struct InputView {
     static private let guideMessage = "분석할 JSON 데이터를 입력하세요."
-    static private let inputFileDirPath = "/Users/yxxjy/DevNote/swift-jsonparser/"
-    
-    enum Arguments: Int {
-        case projectDirectory = 0, inputFile, outputFile
-    }
-    
-    static func readArgument(atIndex index: Arguments) -> String? {
-        let index = index.rawValue
-        let args = CommandLine.arguments
-        guard index < args.count else { return nil }
-        return args[index]
-    }
 
-    static func readContents(from file: String) -> String? {
-        guard let data = FileManager.default.contents(atPath: "\(inputFileDirPath)\(file)") else { return nil }
-        return String(decoding: data, as: UTF8.self)
-    }
-    
     static func readInput() -> String {
         print(guideMessage)
         guard let input: String = readLine() else { return String() }

--- a/JSONParser/JSONParser/InputView.swift
+++ b/JSONParser/JSONParser/InputView.swift
@@ -10,7 +10,24 @@ import Foundation
 
 struct InputView {
     static private let guideMessage = "분석할 JSON 데이터를 입력하세요."
+    static private let inputFileDirPath = "/Users/yxxjy/DevNote/swift-jsonparser/"
+    
+    enum Arguments: Int {
+        case projectDirectory = 0, inputFile, outputFile
+    }
+    
+    static func readArgument(atIndex index: Arguments) -> String? {
+        let index = index.rawValue
+        let args = CommandLine.arguments
+        guard index < args.count else { return nil }
+        return args[index]
+    }
 
+    static func readContents(from file: String) -> String? {
+        guard let data = FileManager.default.contents(atPath: "\(inputFileDirPath)\(file)") else { return nil }
+        return String(decoding: data, as: UTF8.self)
+    }
+    
     static func readInput() -> String {
         print(guideMessage)
         guard let input: String = readLine() else { return String() }

--- a/JSONParser/JSONParser/JSONParser.swift
+++ b/JSONParser/JSONParser/JSONParser.swift
@@ -69,6 +69,7 @@ struct JSONParser {
 
     static func parse(_ jsonString: String) -> JSONDataForm? {
         let jsonString = jsonString.trimWhiteSpaces()
+                                    .trimNewLine()
         if jsonString.hasSideSquareBrackets() {
             guard GrammarChecker.isValid(jsonString, for: JSONRegex.jsonArray) else { return nil }
             guard let jsonArray = makeJSONArray(from: jsonString) else { return nil }

--- a/JSONParser/JSONParser/JSONParserExecutable.swift
+++ b/JSONParser/JSONParser/JSONParserExecutable.swift
@@ -27,6 +27,7 @@ struct JSONLineParser: JSONParserExecutable {
 }
 
 struct JSONFileParser: JSONParserExecutable {
+    private let defaultOutputFile = "output.json"
 
     func read() -> String? {
         guard let file = CommandLineReader.readArgument(atIndex: .inputFile) else { return nil }
@@ -35,7 +36,8 @@ struct JSONFileParser: JSONParserExecutable {
     }
     
     func makeResult(of jsonDataForm: JSONDataForm) {
-        OutputView.writeJSONPrettyPrinted(of: jsonDataForm)
+        let file = CommandLineReader.readArgument(atIndex: .outputFile) ?? defaultOutputFile
+        OutputView.writeJSONPrettyPrinted(of: jsonDataForm, to: file)
     }
 
 }

--- a/JSONParser/JSONParser/JSONParserExecutable.swift
+++ b/JSONParser/JSONParser/JSONParserExecutable.swift
@@ -1,0 +1,41 @@
+//
+//  JSONParserExcutable.swift
+//  JSONParser
+//
+//  Created by 윤지영 on 12/11/2018.
+//  Copyright © 2018 JK. All rights reserved.
+//
+
+import Foundation
+
+protocol JSONParserExecutable {
+    func read() -> String?
+    func makeResult(of: JSONDataForm)
+}
+
+struct JSONLineParser: JSONParserExecutable {
+
+    func read() -> String? {
+        let jsonString = InputView.readInput()
+        return jsonString
+    }
+    
+    func makeResult(of jsonDataForm: JSONDataForm) {
+        OutputView.showJSONPrettyPrinted(of: jsonDataForm)
+    }
+
+}
+
+struct JSONFileParser: JSONParserExecutable {
+
+    func read() -> String? {
+        guard let file = CommandLineReader.readArgument(atIndex: .inputFile) else { return nil }
+        guard let jsonString = FileReader.readContents(from: file) else { return nil }
+        return jsonString
+    }
+    
+    func makeResult(of jsonDataForm: JSONDataForm) {
+        OutputView.writeJSONPrettyPrinted(of: jsonDataForm)
+    }
+
+}

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,12 +9,10 @@
 import Foundation
 
 struct OutputView {
-    static private let outputFileDirPath = "/Users/yxxjy/DevNote/swift-jsonparser/"
     static private let defaultOutputFile = "output.json"
     
     struct Message {
         enum Error: String {
-            case noInputFile = "파싱할 JSON 파일이 미지정되었습니다."
             case invalidForm = "지원하지 않는 형식을 포함하고 있습니다."
             case unableToSave = "정상적으로 저장되지 않았습니다."
         }
@@ -50,8 +48,8 @@ struct OutputView {
     
     static func writeJSONPrettyPrinted(of jsonDataForm: JSONDataForm) {
         let contents = jsonDataForm.prettyPrinted
-        let file = InputView.readArgument(atIndex: .outputFile) ?? defaultOutputFile
-        let fileURL = URL(fileURLWithPath: "\(outputFileDirPath)\(file)")
+        let file = CommandLineReader.readArgument(atIndex: .outputFile) ?? defaultOutputFile
+        guard let fileURL = FileReader.getDocumentURL(with: file) else { return }
         do {
             try contents.write(to: fileURL, atomically: true, encoding: .utf8)
         } catch {

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,8 +9,6 @@
 import Foundation
 
 struct OutputView {
-    static private let defaultOutputFile = "output.json"
-    
     struct Message {
         enum Error: String {
             case invalidForm = "지원하지 않는 형식을 포함하고 있습니다."
@@ -46,9 +44,8 @@ struct OutputView {
         print(jsonDataForm.prettyPrinted)
     }
     
-    static func writeJSONPrettyPrinted(of jsonDataForm: JSONDataForm) {
+    static func writeJSONPrettyPrinted(of jsonDataForm: JSONDataForm, to file: String) {
         let contents = jsonDataForm.prettyPrinted
-        let file = CommandLineReader.readArgument(atIndex: .outputFile) ?? defaultOutputFile
         guard let fileURL = FileReader.getDocumentURL(with: file) else { return }
         do {
             try contents.write(to: fileURL, atomically: true, encoding: .utf8)

--- a/JSONParser/JSONParser/OutputView.swift
+++ b/JSONParser/JSONParser/OutputView.swift
@@ -9,8 +9,15 @@
 import Foundation
 
 struct OutputView {
-    private struct Message {
-        static let invalidForm = "지원하지 않는 형식을 포함하고 있습니다."
+    static private let outputFileDirPath = "/Users/yxxjy/DevNote/swift-jsonparser/"
+    static private let defaultOutputFile = "output.json"
+    
+    struct Message {
+        enum Error: String {
+            case noInputFile = "파싱할 JSON 파일이 미지정되었습니다."
+            case invalidForm = "지원하지 않는 형식을 포함하고 있습니다."
+            case unableToSave = "정상적으로 저장되지 않았습니다."
+        }
 
         struct countResult {
             static let noCount = 0
@@ -40,8 +47,19 @@ struct OutputView {
     static func showJSONPrettyPrinted(of jsonDataForm: JSONDataForm) {
         print(jsonDataForm.prettyPrinted)
     }
+    
+    static func writeJSONPrettyPrinted(of jsonDataForm: JSONDataForm) {
+        let contents = jsonDataForm.prettyPrinted
+        let file = InputView.readArgument(atIndex: .outputFile) ?? defaultOutputFile
+        let fileURL = URL(fileURLWithPath: "\(outputFileDirPath)\(file)")
+        do {
+            try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            notifyIssue(of: .unableToSave)
+        }
+    }
 
-    static func notifyIssue() {
-        print(Message.invalidForm)
+    static func notifyIssue(of error: Message.Error) {
+        print(error.rawValue)
     }
 }

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -9,18 +9,21 @@
 import Foundation
 
 struct Main {
-    static func run() {
-        guard let file = InputView.readArgument(atIndex: .inputFile) else {
-            OutputView.notifyIssue(of: .noInputFile)
-            return
+
+    private static func decideProgram() -> JSONParserExecutable {
+        if CommandLineReader.hasArgument(atIndex: .inputFile) {
+            return JSONFileParser()
         }
-        guard let jsonString = InputView.readContents(from: file) else { return }
-        guard let jsonDataForm: JSONDataForm = JSONParser.parse(jsonString) else {
-            OutputView.notifyIssue(of: .invalidForm)
-            return
-        }
-        OutputView.writeJSONPrettyPrinted(of: jsonDataForm)
+        return JSONLineParser()
     }
+    
+    static func run() {
+        let jsonParserProgram = decideProgram()
+        guard let jsonString = jsonParserProgram.read() else { return }
+        guard let jsonDataForm = JSONParser.parse(jsonString) else { return }
+        jsonParserProgram.makeResult(of: jsonDataForm)
+    }
+
 }
 
 Main.run()

--- a/JSONParser/JSONParser/main.swift
+++ b/JSONParser/JSONParser/main.swift
@@ -10,12 +10,16 @@ import Foundation
 
 struct Main {
     static func run() {
-        let jsonString = InputView.readInput()
-        guard let jsonDataForm: JSONDataForm = JSONParser.parse(jsonString) else {
-            OutputView.notifyIssue()
+        guard let file = InputView.readArgument(atIndex: .inputFile) else {
+            OutputView.notifyIssue(of: .noInputFile)
             return
         }
-        OutputView.showJSONPrettyPrinted(of: jsonDataForm)
+        guard let jsonString = InputView.readContents(from: file) else { return }
+        guard let jsonDataForm: JSONDataForm = JSONParser.parse(jsonString) else {
+            OutputView.notifyIssue(of: .invalidForm)
+            return
+        }
+        OutputView.writeJSONPrettyPrinted(of: jsonDataForm)
     }
 }
 


### PR DESCRIPTION
- JSON 파일명을 argument로 받아 파싱 결과를 새로운 파일에 저장하는 기능을 `InputView` 와 `OutputView` 에 각각 추가했습니다. ( argument로 파일명만을 받아오기 위해 디렉토리 위치는 미리 상수로 지정해두었습니다. )
- JSON 파일 확장자를 `.gitignore` 에 추가해 읽고 새로 저장한 JSON 파일은 리모트 저장소에 올라가지 않도록 했습니다. 